### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
- This is a comment.
+# This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+ This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @alphagov/forms-devs will be requested for
+# review when someone opens a pull request.
+* @alphagov/forms-devs


### PR DESCRIPTION
Adds the same CODEOWNERS file we're using in forms-admin and elsewhere. forms-devs will be added as the default reviewer on all PRs in this repo.