### PR TITLE
Tweak of tagline

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -10,8 +10,7 @@ layout: govuk_wide
         <h1 class="hero__title">Create online forms for GOV.UK</h1>
 
         <p class="hero__description">
-          Create an accessible online form in minutes without technical
-          knowledge.
+          Create an accessible online form in minutes without needing technical knowledge.
         </p>
 
         <p class="hero__paragraph">
@@ -42,7 +41,7 @@ layout: govuk_wide
       <div class="hero__aside-image">
         <img
           src="/images/homepage-illustration.svg"
-          alt=""
+          alt="Simplified "
           role="presentation"
         />
       </div>
@@ -59,7 +58,7 @@ layout: govuk_wide
         <h2 class="govuk-heading-l">Easy to use</h2>
         <div class="govuk-body">
           Create online forms using a simple interface with no need for
-          technical or design skills.
+          coding or design skills.
         </div>
       </div>
     </div>


### PR DESCRIPTION
This is following feedback that it could be read as exclusionary to people who have other kinds of technical knowledge. New wording to make it clearer that you don’t NEED to have any technical knowledge to use the platform.

Also changed 'technical' to 'coding' in the 'Easy to use' section to be more specific, and to avoid repeating 'technical'.