### PR TITLE
Use typographic apostrophe on product page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -79,7 +79,7 @@ layout: govuk_wide
         <h2 class="govuk-heading-l">Fewer errors</h2>
         <div class="govuk-body">
           Form responses are automatically checked for missing answers or
-          answers in the wrong format, so there's less missing information and
+          answers in the wrong format, so there’s less missing information and
           fewer errors compared to document-based forms like PDFs.
         </div>
       </div>


### PR DESCRIPTION
> Straight quotes are a typewriter habit. In traditional printing, all quotation marks were curly. But typewriter character sets were limited by mechanical constraints and physical space.
>
> […]
>
> Compared to straight quotes, curly quotes are more legible on the page and match the other characters better.

– https://practicaltypography.com/straight-and-curly-quotes.html

This commit replaces the use of a straight single quotation mark as an apostrophe with the typographically-correct equivalent.