### PR TITLE
Add autofill and draft features

### DIFF
--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -53,26 +53,22 @@ layout: govuk
   most commonly needed form features first.
 </p>
 
-<h3 class="govuk-heading-m">Create simple questions</h3>
+<h3 class="govuk-heading-m">Create questions</h3>
 
 <p>You can create questions to ask for:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>a short text answer</li>
-  <li>a long text answer</li>
-  <li>a date</li>
-  <li>a UK address</li>
-  <li>a National Insurance number</li>
+  <li>a person’s name</li>
+  <li>an organisation’s name</li>
   <li>a phone number</li>
   <li>an email address</li>
+  <li>a UK or international address</li>
+  <li>a National Insurance number</li>
+  <li>a date</li>
   <li>a number</li>
   <li>a selection of one or more answers from a list of options</li>
+  <li>a short or long text answer</li>
 </ul>
-
-<p>
-  When people complete the form, their responses will be validated to make sure
-  they’re in the correct format. 
-</p>
 
 <p>You can also:</p>
 
@@ -80,6 +76,19 @@ layout: govuk
   <li>add a hint to a question to help people answer it</li>
   <li>make a question optional</li>
 </ul>
+
+<h3 class="govuk-heading-m">
+  Help people answer questions accurately and easily
+</h3>
+
+<p>
+  When people complete a form, their responses will be validated to make sure
+  they’re in the correct format. 
+</p>
+
+<p>
+  For questions that ask for certain types of personal information (such as a name, address or date of birth) people will be able to automatically fill in the answers from their browser.
+</p>
 
 <h3 class="govuk-heading-m">
   Forms use GOV.UK Design System styles, components and patterns
@@ -163,16 +172,24 @@ layout: govuk
   know if there are any problems with your form.
 </p>
 
+<h3 class="govuk-heading-m">
+  Prepare changes to a live form in a draft
+</h3>
+
+<p>
+  You can make a draft version of a live form so you can prepare changes to it. This means you can share the new draft for review before you make the changes live. It also minimises disruption to people who might be filling in the form when you update it. 
+</p>
+
 <h2 class="govuk-heading-l">Features we’re working on next</h2>
 
 <p>These are the features we’re working on now and next:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>Enabling autofill for questions that ask for certain types of personal information - to make it easier for people to answer those questions</li>
   <li>Simple logic to skip questions based on a response</li>
-  <li>Draft functionality - so forms can be edited without affecting the live version until the changes are ready to be made live</li>
   <li>User management and permissions to control what users can and cannot do</li>
-  <li>The ability to add longer guidance for more complex questions</li>
+  <li>Adding longer guidance for more complex questions</li>
+  <li>Asking a question multiple times - for example to collect a history of home addresses</li>
+  <li>The ability for people to create an account and trial the product</li>
 </ul>
 
 <h2 class="govuk-heading-l">Updates</h2>


### PR DESCRIPTION
Added completed features:
- Draft of a live form functionality
- Autofill functionality for accessibility

Removed the above from future features and added in:
- questions you can answer more than once
- ability to make an account and trial the product

Trello:https://trello.com/c/u86TWxRb/671-update-features-page-on-product-site-autofill-and-draft-functionality