### PR TITLE
Add analytics

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -45,6 +45,8 @@ page '/*.txt', layout: false
 # Methods defined in the helpers block are available in templates
 # https://middlemanapp.com/basics/helper-methods/
 
+config[:service_name] = 'GOV.UK Forms'
+
 # helpers do
 #   def some_helper
 #     'Helping'

--- a/jest-puppeteer.config.mjs
+++ b/jest-puppeteer.config.mjs
@@ -7,6 +7,7 @@ export default {
     command: 'bundle exec middleman --port 8888 --watcher-disable',
     port: 8888,
     launchTimeout: 9000,
-    debug: true
+    debug: true,
+    usedPortAction: 'kill'
   }
 }

--- a/source/_cookie_banner.html.erb
+++ b/source/_cookie_banner.html.erb
@@ -1,0 +1,21 @@
+<div id="cookie-banner" class="govuk-cookie-banner" hidden="true" data-nosnippet role="region" aria-label="Cookies on <%= config[:service_name] %>" data-module="cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on <%= config[:service_name] %></h2>
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use this website and make improvements.</p>
+        </div>
+      </div>
+    </div>
+    <div class="govuk-button-group">
+      <button type="button" class="govuk-button" data-module="govuk-button" data-function="accept-cookies">
+        Accept analytics cookies
+      </button>
+      <button type="button" class="govuk-button" data-module="govuk-button" data-function="reject-cookies">
+        Reject analytics cookies
+      </button>
+      <%= link_to 'How we use cookies', '/cookies', class: 'govuk-link' %>
+    </div>
+  </div>
+</div>

--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -68,7 +68,7 @@ layout: govuk
 </table>
 
 
-<h2 class="govuk-heading-l">Analytics cookies (optional)</h2>
+<h2 class="govuk-heading-l">Analytics cookies on this website (optional)</h2>
 <p>We use Google Analytics software to understand how people use the GOV.UK Forms website. This information helps us to improve our service.</p>
 <p>Google is not allowed to use or share our analytics data with anyone.</p>
 <p>Google Analytics stores anonymised information about:</p>
@@ -174,8 +174,18 @@ layout: govuk
   </button>
 </form>
 
+<h2 class="govuk-heading-l">Cookies on our mailing list sign up page</h2>
 
-<h2 class="govuk-heading-l">Essential cookies on GOV.UK Forms</h2>
+<p>
+  We use the Mailchimp platform to send email updates to people who register
+  interest in using GOV.UK Forms. Mailchimp uses cookies on the sign up page for
+  the mailing list. For more information you can read the
+  <a href="https://mailchimp.com/en-gb/legal/cookies"
+    >Mailchimp cookie statement</a
+  >.
+</p>
+
+<h2 class="govuk-heading-l">Essential cookies on the GOV.UK Forms product</h2>
 <p>We use essential cookies to make the GOV.UK Forms product work.</p>
 
 <table class="govuk-table">
@@ -206,15 +216,6 @@ layout: govuk
   </tbody>
 </table>
 
-<h2 class="govuk-heading-l">Cookies on our mailing list sign up page</h2>
 
-<p>
-  We use the Mailchimp platform to send email updates to people who register
-  interest in using GOV.UK Forms. Mailchimp uses cookies on the sign up page for
-  the mailing list. For more information you can read the
-  <a href="https://mailchimp.com/en-gb/legal/cookies"
-    >Mailchimp cookie statement</a
-  >.
-</p>
 
 </div>

--- a/source/cookies.html.erb
+++ b/source/cookies.html.erb
@@ -3,43 +3,180 @@ title: "Cookies"
 layout: govuk
 ---
 
+<%# Don't show the cookie banner on this page %>
+<% content_for :cookie_banner do %>
+  <!-- no cookie banner -->
+<% end %>
+
+<div class="app-cookies-page" data-module="app-cookies-page">
+  <div
+    class="govuk-notification-banner govuk-notification-banner--success js-cookies-page-success"
+    role="alert"
+    aria-labelledby="govuk-notification-banner-title"
+    data-module="govuk-notification-banner"
+    hidden=""
+  >
+    <div class="govuk-notification-banner__header">
+      <h2
+        class="govuk-notification-banner__title"
+        id="govuk-notification-banner-title"
+      >
+        Success
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        You’ve set your cookie preferences.
+      </p>
+    </div>
+  </div>
 <h1 class="govuk-heading-xl">Cookies</h1>
 <p>
   Cookies are small files saved on your phone, tablet or computer when you visit
   a website.
 </p>
 
-<p>
-  We don’t use any cookies on the GOV.UK Forms website. However, cookies are
-  used by our mailing list supplier on the sign up page for our mailing list.
-</p>
+<p>We use cookies to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>collect information about how you use this website</li>
+  <li>make GOV.UK Forms work</li>
+</ul>
 
-<p>We also use cookies to make the GOV.UK Forms product work.</p>
+<p>Our mailing list supplier also uses cookies on the sign up page for our mailing list.</p>
 
-<p>
-  Find out
-  <a href="https://ico.org.uk/your-data-matters/online/cookies/"
-    >how to manage cookies</a
-  >.
-</p>
+<p>Find out <a href="https://ico.org.uk/your-data-matters/online/cookies/">how to manage cookies</a>.</p>
 
-<h2 class="govuk-heading-l">Cookies on our mailing list sign up page</h2>
+<h2 class="govuk-heading-l">Essential cookies on this website</h2>
 
-<p>
-  We use the Mailchimp platform to send email updates to people who register
-  interest in using GOV.UK Forms. Mailchimp uses cookies on the sign up page for
-  the mailing list. For more information you can read the
-  <a href="https://mailchimp.com/en-gb/legal/cookies"
-    >Mailchimp cookie statement</a
-  >.
-</p>
+<p>We use an essential cookie to remember when you accept or reject cookies on this website.</p>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Purpose</th>
+      <th scope="col" class="govuk-table__header">Expires</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">analytics_consent</th>
+      <td class="govuk-table__cell">Saves your cookie consent settings</td>
+      <td class="govuk-table__cell">1 year</td>
+    </tr>
+  </tbody>
+</table>
+
+
+<h2 class="govuk-heading-l">Analytics cookies (optional)</h2>
+<p>We use Google Analytics software to understand how people use the GOV.UK Forms website. This information helps us to improve our service.</p>
+<p>Google is not allowed to use or share our analytics data with anyone.</p>
+<p>Google Analytics stores anonymised information about:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>the pages you visit</li>
+  <li>how long you spend on each page</li>
+  <li>how you arrived at the site</li>
+  <li>what you click on while you visit the site</li>
+  <li>the device and browser you use</li>
+</ul>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption">
+    Analytics cookies we use
+  </caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Purpose</th>
+      <th scope="col" class="govuk-table__header">Expires</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">_ga</th>
+      <td class="govuk-table__cell">
+        Helps us count how many people visit the GOV.UK Forms website by
+        telling us if you’ve visited before.
+      </td>
+      <td class="govuk-table__cell">2 years</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">_gid</th>
+      <td class="govuk-table__cell">
+        Helps us count how many people visit the GOV.UK Forms website by
+        telling us if you’ve visited before.
+      </td>
+      <td class="govuk-table__cell">24 hours</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">
+        _gat_UA-[random number]
+      </th>
+      <td class="govuk-table__cell">
+        Used to reduce the number of requests.
+      </td>
+      <td class="govuk-table__cell">1 minute</td>
+    </tr>
+  </tbody>
+</table>
+
+<form class="js-cookies-page-form">
+  <div class="govuk-form-group">
+    <fieldset
+      class="govuk-fieldset js-cookies-page-form-fieldset"
+      id="analytics"
+      hidden=""
+      >
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        Do you want to accept analytics cookies?
+      </legend>
+      <div class="govuk-radios" data-module="govuk-radios">
+        <div class="govuk-radios__item">
+          <input
+            class="govuk-radios__input"
+            id="radio-analytics"
+            name="analytics"
+            type="radio"
+            value="yes"
+            />
+          <label
+            class="govuk-label govuk-radios__label"
+            for="radio-analytics"
+            >
+            Yes
+          </label>
+        </div>
+        <div class="govuk-radios__item">
+          <input
+            class="govuk-radios__input"
+            id="radio-analytics-2"
+            name="analytics"
+            type="radio"
+            value="no"
+            />
+          <label
+            class="govuk-label govuk-radios__label"
+            for="radio-analytics-2"
+            >
+            No
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+
+  <button
+    class="govuk-button js-cookies-form-button"
+    data-module="govuk-button"
+    hidden=""
+    >
+    Save cookie settings
+  </button>
+</form>
+
 
 <h2 class="govuk-heading-l">Essential cookies on GOV.UK Forms</h2>
-
-<p>
-  We use essential cookies to make the GOV.UK Forms product work.
-  UK law does not require us to ask for consent for these cookies because they are essential for the service to function.
-</p>
+<p>We use essential cookies to make the GOV.UK Forms product work.</p>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -68,3 +205,16 @@ layout: govuk
     </tr>
   </tbody>
 </table>
+
+<h2 class="govuk-heading-l">Cookies on our mailing list sign up page</h2>
+
+<p>
+  We use the Mailchimp platform to send email updates to people who register
+  interest in using GOV.UK Forms. Mailchimp uses cookies on the sign up page for
+  the mailing list. For more information you can read the
+  <a href="https://mailchimp.com/en-gb/legal/cookies"
+    >Mailchimp cookie statement</a
+  >.
+</p>
+
+</div>

--- a/source/javascripts/components/cookie_banner.mjs
+++ b/source/javascripts/components/cookie_banner.mjs
@@ -1,0 +1,37 @@
+export function CookieBanner ($module) {
+  this.$module = $module
+  this.$acceptButton = $module.querySelector('[data-function="accept-cookies"]')
+  this.$rejectButton = $module.querySelector('[data-function="reject-cookies"]')
+}
+
+CookieBanner.prototype.init = function (options) {
+  options = options || {}
+  options.showBanner = options.showBanner || false
+  options.onSubmit = options.onSubmit || function () {}
+
+  this.onSubmit(options.onSubmit)
+  const thisCallback = this.onClick.bind(this)
+  this.$acceptButton.addEventListener('click', function () { thisCallback(true) })
+  this.$rejectButton.addEventListener('click', function () { thisCallback(false) })
+
+  if (options.showBanner) {
+    this.show()
+  }
+}
+
+CookieBanner.prototype.show = function () {
+  this.$module.removeAttribute('hidden')
+}
+
+CookieBanner.prototype.hide = function () {
+  this.$module.setAttribute('hidden', 'true')
+}
+
+CookieBanner.prototype.onSubmit = function (cb) {
+  this.onSubmitCallback = cb
+}
+
+CookieBanner.prototype.onClick = function (allowAnalyticsCookies) {
+  this.onSubmitCallback(allowAnalyticsCookies)
+  this.hide()
+}

--- a/source/javascripts/components/cookie_banner.test.mjs
+++ b/source/javascripts/components/cookie_banner.test.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from 'fs'
+import { CookieBanner } from './cookie_banner.mjs'
+
+describe('CookieBanner', () => {
+  let cookieBanner
+  const cookieBannerHTML = readFileSync('tests/fixtures/cookie_banner.html', 'utf8')
+
+  beforeEach(() => {
+    document.body.innerHTML = cookieBannerHTML
+    cookieBanner = new CookieBanner(document.querySelector('#cookie-banner'))
+  })
+
+  test('Initialzes ok when given valid html', () => {
+    expect(cookieBanner).toBeDefined()
+  })
+
+  describe('When given no options', () => {
+    test('is hidden', () => {
+      cookieBanner.init()
+      expect(document.querySelector('#cookie-banner').getAttribute('hidden')).toBe('true')
+    })
+  })
+
+  test('show', () => {
+    cookieBanner.show()
+    expect(document.querySelector('#cookie-banner').hasAttribute('hidden')).toBe(false)
+  })
+})

--- a/source/javascripts/components/cookie_page.mjs
+++ b/source/javascripts/components/cookie_page.mjs
@@ -1,0 +1,67 @@
+export function CookiePage ($module) {
+  this.$module = $module
+}
+
+CookiePage.prototype.init = function (options) {
+  this.$cookiePage = this.$module
+
+  if (!this.$cookiePage) {
+    return
+  }
+
+  options = options || {}
+  options.allowAnalyticsCookies = options.allowAnalyticsCookies || false
+  options.onSubmit = options.onSubmit || function () {}
+
+  this.$cookieForm = this.$cookiePage.querySelector('.js-cookies-page-form')
+  this.$cookieFormFieldsets = this.$cookieForm.querySelectorAll('.js-cookies-page-form-fieldset')
+  this.$analyticsFieldset = this.$cookieForm.querySelector('#analytics')
+
+  this.$successNotification = this.$cookiePage.querySelector('.js-cookies-page-success')
+
+  this.onSubmit(options.onSubmit)
+
+  this.showUserPreference(this.$analyticsFieldset, options.allowAnalyticsCookies)
+  this.$analyticsFieldset.removeAttribute('hidden')
+
+  // Show submit button
+  this.$cookieForm.querySelector('.js-cookies-form-button').removeAttribute('hidden')
+  this.$cookieForm.addEventListener('submit', this.savePreferences.bind(this))
+}
+
+CookiePage.prototype.onSubmit = function (cb) {
+  this.onSubmitCallback = cb
+}
+
+CookiePage.prototype.savePreferences = function (event) {
+  event.preventDefault()
+
+  const selectedItem = this.$analyticsFieldset.querySelector('input[name=' + 'analytics' + ']:checked').value
+
+  this.onSubmitCallback(selectedItem === 'yes')
+  this.showSuccessNotification()
+}
+
+CookiePage.prototype.showUserPreference = function ($cookieFormFieldset, preference) {
+  const radioValue = preference ? 'yes' : 'no'
+  const radio = $cookieFormFieldset.querySelector('input[name=analytics][value=' + radioValue + ']')
+  radio.checked = true
+}
+
+CookiePage.prototype.showSuccessNotification = function () {
+  this.$successNotification.removeAttribute('hidden')
+
+  // Set tabindex to -1 to make the element focusable with JavaScript.
+  // GOV.UK Frontend will remove the tabindex on blur as the component doesn't
+  // need to be focusable after the user has read the text.
+  if (!this.$successNotification.getAttribute('tabindex')) {
+    this.$successNotification.setAttribute('tabindex', '-1')
+  }
+
+  this.$successNotification.focus()
+
+  // scroll to the top of the page
+  window.scrollTo(0, 0)
+}
+
+export default CookiePage

--- a/source/javascripts/components/cookie_page.mjs
+++ b/source/javascripts/components/cookie_page.mjs
@@ -36,7 +36,7 @@ CookiePage.prototype.onSubmit = function (cb) {
 CookiePage.prototype.savePreferences = function (event) {
   event.preventDefault()
 
-  const selectedItem = this.$analyticsFieldset.querySelector('input[name=' + 'analytics' + ']:checked').value
+  const selectedItem = this.$analyticsFieldset.querySelector('input[name=analytics]:checked').value
 
   this.onSubmitCallback(selectedItem === 'yes')
   this.showSuccessNotification()

--- a/source/javascripts/components/cookie_page.test.mjs
+++ b/source/javascripts/components/cookie_page.test.mjs
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs'
+import { CookiePage } from './cookie_page.mjs'
+
+describe('CookiePage', () => {
+  let cookiePage
+  const cookiePageHTML = readFileSync('tests/fixtures/cookie_page.html', 'utf8')
+
+  beforeEach(() => {
+    document.body.innerHTML = cookiePageHTML
+    cookiePage = new CookiePage(document.querySelector('[data-module="app-cookies-page"]'))
+  })
+
+  test('Initialzes ok when given valid html', () => {
+    expect(cookiePage).toBeDefined()
+  })
+})

--- a/source/javascripts/services/cookie.mjs
+++ b/source/javascripts/services/cookie.mjs
@@ -8,8 +8,8 @@ export const CONSENT_STATUS = {
 
 export function loadConsentStatus () {
   const cookies = document.cookie ? document.cookie.split('; ') : []
-  for (let i = 0; i < cookies.length; i++) {
-    const cookie = cookies[i].split('=')
+  cookies.forEach(function (rawCookie) {
+    cookie = cookies[i].split('=')
     if (cookie[0] === COOKIE_NAME) {
       if (cookie[1] === 'true') {
         return CONSENT_STATUS.GRANTED
@@ -17,7 +17,7 @@ export function loadConsentStatus () {
 
       return CONSENT_STATUS.DENIED
     }
-  }
+  })
 
   return CONSENT_STATUS.UNKNOWN
 }

--- a/source/javascripts/services/cookie.mjs
+++ b/source/javascripts/services/cookie.mjs
@@ -1,0 +1,29 @@
+export const COOKIE_NAME = 'analytics_consent'
+
+export const CONSENT_STATUS = {
+  GRANTED: 'CONSENT_GRANTED',
+  DENIED: 'CONSENT_DENIED',
+  UNKNOWN: 'CONSENT_UNKNOWN'
+}
+
+export function loadConsentStatus () {
+  const cookies = document.cookie ? document.cookie.split('; ') : []
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].split('=')
+    if (cookie[0] === COOKIE_NAME) {
+      if (cookie[1] === 'true') {
+        return CONSENT_STATUS.GRANTED
+      }
+
+      return CONSENT_STATUS.DENIED
+    }
+  }
+
+  return CONSENT_STATUS.UNKNOWN
+}
+
+export function saveConsentStatus (consent, date) {
+  date = date || new Date()
+  date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000))
+  document.cookie = COOKIE_NAME + '=' + consent + '; expires=' + date.toGMTString()
+}

--- a/source/javascripts/services/cookie.mjs
+++ b/source/javascripts/services/cookie.mjs
@@ -8,8 +8,8 @@ export const CONSENT_STATUS = {
 
 export function loadConsentStatus () {
   const cookies = document.cookie ? document.cookie.split('; ') : []
-  cookies.forEach(function (rawCookie) {
-    cookie = cookies[i].split('=')
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].split('=')
     if (cookie[0] === COOKIE_NAME) {
       if (cookie[1] === 'true') {
         return CONSENT_STATUS.GRANTED
@@ -17,7 +17,7 @@ export function loadConsentStatus () {
 
       return CONSENT_STATUS.DENIED
     }
-  })
+  }
 
   return CONSENT_STATUS.UNKNOWN
 }

--- a/source/javascripts/services/cookie.test.mjs
+++ b/source/javascripts/services/cookie.test.mjs
@@ -7,12 +7,11 @@ describe('Cookie', () => {
     // delete all cookies between tests
     const cookies = document.cookie.split(';')
 
-    for (let i = 0; i < cookies.length; i++) {
-      const cookie = cookies[i]
+    cookies.forEach(function (cookie) {
       const eqPos = cookie.indexOf('=')
       const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie
       document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT'
-    }
+    })
   })
 
   describe('loadConsentStatus', () => {

--- a/source/javascripts/services/cookie.test.mjs
+++ b/source/javascripts/services/cookie.test.mjs
@@ -1,0 +1,67 @@
+import { loadConsentStatus, saveConsentStatus, COOKIE_NAME, CONSENT_STATUS } from './cookie.mjs'
+
+describe('Cookie', () => {
+  const cookieValue = `${COOKIE_NAME}=true`
+
+  afterEach(() => {
+    // delete all cookies between tests
+    const cookies = document.cookie.split(';')
+
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i]
+      const eqPos = cookie.indexOf('=')
+      const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie
+      document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT'
+    }
+  })
+
+  describe('loadConsentStatus', () => {
+    it('returns "GRANTED" when cookie set to true', () => {
+      window.document.cookie = `${COOKIE_NAME}=true`
+      expect(loadConsentStatus(cookieValue)).toBe(CONSENT_STATUS.GRANTED)
+    })
+
+    it('returns "DENIED" when cookie set to anything but true', () => {
+      window.document.cookie = `${COOKIE_NAME}=asdj`
+      expect(loadConsentStatus(cookieValue)).toBe(CONSENT_STATUS.DENIED)
+    })
+
+    it('returns "UNKNOWN" when cookie set to true', () => {
+      window.document.cookie = 'wrong_cookie_name=true'
+      expect(loadConsentStatus(cookieValue)).toBe(CONSENT_STATUS.UNKNOWN)
+    })
+  })
+
+  describe('saveConsentStatus', () => {
+    beforeEach(() => {
+      Object.defineProperty(window.document, 'cookie', {
+        writable: true,
+        value: ''
+      })
+    })
+
+    it('writes the correct value to the cookie when given true', () => {
+      const fixedTestDate = new Date(2023, 1, 1, 0, 0, 0, 0)
+      saveConsentStatus(true, fixedTestDate)
+      expect(window.document.cookie).toBe('analytics_consent=true; expires=Thu, 01 Feb 2024 00:00:00 GMT')
+    })
+
+    it('writes the correct value to the cookie when given false', () => {
+      const fixedTestDate = new Date(2023, 1, 1, 0, 0, 0, 0)
+      saveConsentStatus(false, fixedTestDate)
+      expect(window.document.cookie).toBe('analytics_consent=false; expires=Thu, 01 Feb 2024 00:00:00 GMT')
+    })
+  })
+
+  describe('saveConsentStatus and loadConsentStatus', () => {
+    it('writes the and reads correct value given true', () => {
+      saveConsentStatus(true)
+      expect(loadConsentStatus(cookieValue)).toBe(CONSENT_STATUS.GRANTED)
+    })
+
+    it('writes the and reads correct value given true', () => {
+      saveConsentStatus(false)
+      expect(loadConsentStatus(cookieValue)).toBe(CONSENT_STATUS.DENIED)
+    })
+  })
+})

--- a/source/javascripts/services/google_tag.mjs
+++ b/source/javascripts/services/google_tag.mjs
@@ -9,14 +9,13 @@
 export function deleteGoogleAnalyticsCookies () {
   const cookies = document.cookie ? document.cookie.split('; ') : []
   let i = 0
-  for (i = 0; i < cookies.length; i++) {
-    const cookie = cookies[i]
+  cookies.forEach(function (cookie) {
     if (cookie.indexOf('_ga') === 0 || cookie.indexOf('_gid') === 0 || cookie.indexOf('_gat') === 0) {
       const domain = window.location.hostname
       const cookieToDelete = cookie.split('=')[0] + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=' + domain
       document.cookie = cookieToDelete
     }
-  }
+  })
 }
 
 export function installAnalyticsScript (global) {
@@ -74,8 +73,8 @@ export function attachExternaLinkTracker () {
   // track external links
   window.addEventListener('load', function () {
     const externalLinks = document.querySelectorAll('a[href^="http"], a[href^="https"]')
-    for (let i = 0; i < externalLinks.length; i++) {
-      externalLinks[i].addEventListener('click', function (event) {
+    externalLinks.forEach(function (externalLink) {
+      externalLink.addEventListener('click', function (event) {
         const target = event.target
         window.dataLayer.push({
           event: 'event_data',
@@ -89,6 +88,6 @@ export function attachExternaLinkTracker () {
           }
         })
       })
-    }
+    })
   })
 }

--- a/source/javascripts/services/google_tag.mjs
+++ b/source/javascripts/services/google_tag.mjs
@@ -1,0 +1,94 @@
+// for use before the google script has been loaded
+// this function is hard to test because arguments ha sbeen deprecated but has better browser support than ...args
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage
+// export function gtag() {
+//   window.dataLayer = window.dataLayer || [];
+//   window.dataLayer.push(arguments);
+// }
+
+export function deleteGoogleAnalyticsCookies () {
+  const cookies = document.cookie ? document.cookie.split('; ') : []
+  let i = 0
+  for (i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i]
+    if (cookie.indexOf('_ga') === 0 || cookie.indexOf('_gid') === 0 || cookie.indexOf('_gat') === 0) {
+      const domain = window.location.hostname
+      const cookieToDelete = cookie.split('=')[0] + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=' + domain
+      document.cookie = cookieToDelete
+    }
+  }
+}
+
+export function installAnalyticsScript (global) {
+  const GTAG_ID = 'GTM-MFJWJNW'
+  if (!window.ga) {
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || []
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      })
+
+      const j = d.createElement(s)
+      const dl = l !== 'dataLayer' ? '&l=' + l : ''
+
+      j.async = true
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+      document.head.appendChild(j)
+    })(global, document, 'script', 'dataLayer', GTAG_ID)
+  }
+}
+
+export function setDefaultConsent (consentedToAnalyticsCookies) {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push(['consent', 'default', {
+    ad_storage: 'denied',
+    analytics_storage: consentedToAnalyticsCookies ? 'granted' : 'denied'
+  }])
+}
+
+export function updateCookieConsent (consentedToAnalyticsCookies) {
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push(['consent', 'update', {
+    analytics_storage: consentedToAnalyticsCookies ? 'granted' : 'denied'
+  }])
+}
+
+export function sendPageViewEvent () {
+  // Ideally this should be placed above the GTM container snippet and early within the <head> tags
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({
+    // Where a property value is not available, set it as undefined
+    event: 'page_view',
+    page_view: {
+      location: document.location,
+      referrer: document.referrer,
+      schema_name: 'simple_schema',
+      status_code: 200,
+      title: document.title
+    }
+  })
+}
+
+export function attachExternaLinkTracker () {
+  // track external links
+  window.addEventListener('load', function () {
+    const externalLinks = document.querySelectorAll('a[href^="http"], a[href^="https"]')
+    for (let i = 0; i < externalLinks.length; i++) {
+      externalLinks[i].addEventListener('click', function (event) {
+        const target = event.target
+        window.dataLayer.push({
+          event: 'event_data',
+          event_data: {
+            event_name: 'navigation',
+            external: true,
+            method: 'primary click',
+            text: target.innerText,
+            type: 'generic link',
+            url: target.href
+          }
+        })
+      })
+    }
+  })
+}

--- a/source/javascripts/services/google_tag.mjs
+++ b/source/javascripts/services/google_tag.mjs
@@ -8,7 +8,6 @@
 
 export function deleteGoogleAnalyticsCookies () {
   const cookies = document.cookie ? document.cookie.split('; ') : []
-  let i = 0
   cookies.forEach(function (cookie) {
     if (cookie.indexOf('_ga') === 0 || cookie.indexOf('_gid') === 0 || cookie.indexOf('_gat') === 0) {
       const domain = window.location.hostname
@@ -70,23 +69,20 @@ export function sendPageViewEvent () {
 }
 
 export function attachExternaLinkTracker () {
-  // track external links
-  window.addEventListener('load', function () {
-    const externalLinks = document.querySelectorAll('a[href^="http"], a[href^="https"]')
-    externalLinks.forEach(function (externalLink) {
-      externalLink.addEventListener('click', function (event) {
-        const target = event.target
-        window.dataLayer.push({
-          event: 'event_data',
-          event_data: {
-            event_name: 'navigation',
-            external: true,
-            method: 'primary click',
-            text: target.innerText,
-            type: 'generic link',
-            url: target.href
-          }
-        })
+  const externalLinks = document.querySelectorAll('a[href^="http"], a[href^="https"]')
+  externalLinks.forEach(function (externalLink) {
+    externalLink.addEventListener('click', function (event) {
+      const target = event.target
+      window.dataLayer.push({
+        event: 'event_data',
+        event_data: {
+          event_name: 'navigation',
+          external: true,
+          method: 'primary click',
+          text: target.innerText,
+          type: 'generic link',
+          url: target.href
+        }
       })
     })
   })

--- a/source/javascripts/services/google_tag.test.mjs
+++ b/source/javascripts/services/google_tag.test.mjs
@@ -1,0 +1,35 @@
+import { deleteGoogleAnalyticsCookies, installAnalyticsScript } from './google_tag.mjs'
+
+describe('google_tag.mjs', () => {
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = ''
+  })
+
+  describe('deleteGoogleAnalyticsCookies()', () => {
+    it('removes google cookies', function () {
+      document.cookie = '_ga=GA1.1.120966789.1687349767'
+      document.cookie = 'analytics_consent=true'
+      document.cookie = '_ga_B0CQCNQ8PH=GS1.1.1687430125.5.0.1687430125.0.0.0'
+
+      deleteGoogleAnalyticsCookies()
+      expect(document.cookie).toContain('analytics_consent=true')
+    })
+  })
+
+  describe('installAnalyticsScript()', () => {
+    it('adds script tag to DOM', function () {
+      installAnalyticsScript(window)
+      expect(document.querySelectorAll('script[src^="https://www.googletagmanager.com/gtm.js"]').length).toBe(1)
+    })
+  })
+
+  it('does not add script tag ig ga already present on window', function () {
+    window.document.write = ''
+    Object.defineProperty(window, 'ga', {
+      writable: true,
+      value: true
+    })
+    installAnalyticsScript(window)
+    expect(document.querySelectorAll('script[src^="https://www.googletagmanager.com/gtm.js"]').length).toBe(0)
+  })
+})

--- a/source/javascripts/site.mjs
+++ b/source/javascripts/site.mjs
@@ -1,3 +1,22 @@
 import { initAll } from 'govuk-frontend'
 
+import { loadConsentStatus, CONSENT_STATUS } from './services/cookie.mjs'
+import { installAnalyticsScript, setDefaultConsent, sendPageViewEvent, attachExternaLinkTracker } from './services/google_tag.mjs'
+
 initAll()
+
+const analyticsConsentStatus = loadConsentStatus()
+
+setDefaultConsent(analyticsConsentStatus === CONSENT_STATUS.GRANTED)
+
+// send pageview regardless of consent value - if consent has not been granted
+// yet, GTM won't be loaded and no data is sent to Google analytics. Doing this
+// now means that if consent is granted later on this page, the event will be
+// sent
+sendPageViewEvent()
+attachExternaLinkTracker()
+
+if (analyticsConsentStatus === CONSENT_STATUS.GRANTED) {
+  installAnalyticsScript(window)
+}
+

--- a/source/javascripts/site.mjs
+++ b/source/javascripts/site.mjs
@@ -1,7 +1,10 @@
 import { initAll } from 'govuk-frontend'
+import { nodeListForEach } from 'govuk-frontend/govuk-esm/common.mjs'
 
-import { loadConsentStatus, CONSENT_STATUS } from './services/cookie.mjs'
-import { installAnalyticsScript, setDefaultConsent, sendPageViewEvent, attachExternaLinkTracker } from './services/google_tag.mjs'
+import { CookieBanner } from './components/cookie_banner.mjs'
+
+import { loadConsentStatus, saveConsentStatus, CONSENT_STATUS } from './services/cookie.mjs'
+import { installAnalyticsScript, deleteGoogleAnalyticsCookies, setDefaultConsent, updateCookieConsent, sendPageViewEvent, attachExternaLinkTracker } from './services/google_tag.mjs'
 
 initAll()
 
@@ -20,3 +23,23 @@ if (analyticsConsentStatus === CONSENT_STATUS.GRANTED) {
   installAnalyticsScript(window)
 }
 
+// Initialise cookie banner
+const $banners = document.querySelectorAll('[data-module="cookie-banner"]')
+nodeListForEach($banners, function ($banner) {
+  new CookieBanner($banner).init({
+    showBanner: analyticsConsentStatus === CONSENT_STATUS.UNKNOWN,
+    onSubmit: handleUpdateConsent
+  })
+})
+
+function handleUpdateConsent (consentedToAnalyticsCookies) {
+  saveConsentStatus(consentedToAnalyticsCookies)
+
+  updateCookieConsent(consentedToAnalyticsCookies)
+
+  if (consentedToAnalyticsCookies === false) {
+    deleteGoogleAnalyticsCookies()
+  } else {
+    installAnalyticsScript(window)
+  }
+}

--- a/source/javascripts/site.mjs
+++ b/source/javascripts/site.mjs
@@ -2,6 +2,7 @@ import { initAll } from 'govuk-frontend'
 import { nodeListForEach } from 'govuk-frontend/govuk-esm/common.mjs'
 
 import { CookieBanner } from './components/cookie_banner.mjs'
+import { CookiePage } from './components/cookie_page.mjs'
 
 import { loadConsentStatus, saveConsentStatus, CONSENT_STATUS } from './services/cookie.mjs'
 import { installAnalyticsScript, deleteGoogleAnalyticsCookies, setDefaultConsent, updateCookieConsent, sendPageViewEvent, attachExternaLinkTracker } from './services/google_tag.mjs'
@@ -31,6 +32,15 @@ nodeListForEach($banners, function ($banner) {
     onSubmit: handleUpdateConsent
   })
 })
+
+// Initialise cookie page
+const $cookiesPage = document.querySelector('[data-module="app-cookies-page"]')
+if ($cookiesPage) {
+  new CookiePage($cookiesPage).init({
+    allowAnalyticsCookies: analyticsConsentStatus === CONSENT_STATUS.GRANTED,
+    onSubmit: handleUpdateConsent
+  })
+}
 
 function handleUpdateConsent (consentedToAnalyticsCookies) {
   saveConsentStatus(consentedToAnalyticsCookies)

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -59,6 +59,13 @@
         : "js-enabled";
     </script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+    <% if content_for?(:cookie_banner) %>
+      <%= yield_content :cookie_banner %>
+    <% else %>
+      <%= partial "cookie_banner" %>
+    <% end %>
+
     <header
       class="govuk-header"
       role="banner"

--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -59,15 +59,14 @@ layout: govuk
   </li>
 </ul>
 <p>
-  We collect this information in system logs. These logs are stored in Amazon
-  Web Services in Ireland.
+  We collect this information in system logs. These logs are stored in Amazon Web
+  Services in the UK.
 </p>
 <p>
   We move some of this information to our security and network monitoring tools
-  in Ireland and the USA which are provided by companies acting as our data
+  in the USA which are provided by companies acting as our data
   processors.
 </p>
-
 <p>
   We may also use this information to produce anonymised reports about the
   GOV.UK Forms service. This helps us understand where we can make improvements.
@@ -148,7 +147,50 @@ layout: govuk
   court order, or to prevent fraud or other crime.
 </p>
 
+<h2 class="govuk-heading-m">
+  Performance analysis
+</h2>
+
+<p>
+  We also carry out performance analysis to see how you use the GOV.UK
+  Forms website and how well the site performs on your device during your
+  visit — we do this to make sure it’s meeting the needs of its users and
+  to improve it.
+</p>
+
+<p>If you provide your consent, we collect the following information:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>your IP address</li>
+  <li>the pages you visit on the GOV.UK Forms website</li>
+  <li>how long you spend on each page</li>
+  <li>how you got to the site</li>
+  <li>what you click on while you’re visiting the site</li>
+</ul>
+
+<p>
+  The legal basis for performing web analytics is your consent. You will be
+  asked for your consent when first landing on this website. If you do not give
+  your consent, you will still be able to use the page. If you do give it and
+  change your mind, you can update your cookie settings.
+</p>
+
 <h2 class="govuk-heading-m">Cookies</h2>
+
+<p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+
+<p>We use cookies to:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>collect information about how you use this website</li>
+  <li>make GOV.UK Forms work</li>
+</ul>
+
+<p>
+  Our mailing list supplier also uses cookies on the sign up page for our mailing list.
+  For more information you can <a href="/cookies">read about the cookies we use</a>.
+</p>
+
 <p>
   We don’t use any cookies on the GOV.UK Forms website. However, Mailchimp uses
   cookies on the sign up page for our mailing list. We also use cookies to make
@@ -166,6 +208,11 @@ layout: govuk
 </ul>
 
 <p>This means that we will only hold your personal data for one year.</p>
+
+<p>
+  If you consent to analytics cookies on the GOV.UK Forms website, your
+  personal data will be retained for 14 months.
+</p>
 
 <p>
   If you have a GOV.UK Forms account, your personal data will be retained while

--- a/tests/fixtures/cookie_banner.html
+++ b/tests/fixtures/cookie_banner.html
@@ -1,0 +1,22 @@
+<div id="cookie-banner" class="govuk-cookie-banner" hidden="true" data-nosnippet role="region" aria-label="Cookies on <%= config[:service_name] %>" data-module="cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on <%= config[:service_name] %></h2>
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use this website and make improvements.</p>
+        </div>
+      </div>
+    </div>
+    <div class="govuk-button-group">
+      <button type="button" class="govuk-button" data-module="govuk-button" data-function="accept-cookies">
+        Accept analytics cookies
+      </button>
+      <button type="button" class="govuk-button" data-module="govuk-button" data-function="reject-cookies">
+        Reject analytics cookies
+      </button>
+      <a href="/cookies" class="govuk-link">How we use cookies</a>
+    </div>
+  </div>
+</div>
+

--- a/tests/fixtures/cookie_page.html
+++ b/tests/fixtures/cookie_page.html
@@ -1,0 +1,179 @@
+<div class="app-cookies-page" data-module="app-cookies-page">
+  <div
+    class="govuk-notification-banner govuk-notification-banner--success js-cookies-page-success"
+    role="alert"
+    aria-labelledby="govuk-notification-banner-title"
+    data-module="govuk-notification-banner"
+    hidden=""
+  >
+    <div class="govuk-notification-banner__header">
+      <h2
+        class="govuk-notification-banner__title"
+        id="govuk-notification-banner-title"
+      >
+        Success
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        You’ve set your cookie preferences.
+      </p>
+    </div>
+  </div>
+
+  <form class="js-cookies-page-form">
+    <h2 class="govuk-heading-l govuk-!-margin-top-6">
+      Essential cookies (strictly necessary)
+    </h2>
+
+    <p class="govuk-body">
+      We use an essential cookie to remember when you accept or reject cookies
+      on our website.
+    </p>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption">
+        Essential cookies we use
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            analytics_consent
+          </th>
+          <td class="govuk-table__cell">Saves your cookie consent settings</td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-6">
+      Analytics cookies (optional)
+    </h2>
+
+    <p class="govuk-body">
+      We use Google Analytics software to understand how people use the GOV.UK
+      Design System. We do this to help make sure the site is meeting the needs
+      of its users and to help us make improvements.
+    </p>
+
+    <p class="govuk-body">
+      We do not collect or store your personal information (for example your
+      name or address) so this information cannot be used to identify who you
+      are.
+    </p>
+
+    <p class="govuk-body">
+      We do not allow Google to use or share our analytics data.
+    </p>
+
+    <p class="govuk-body">Google Analytics stores information about:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the pages you visit</li>
+      <li>how long you spend on each page</li>
+      <li>how you arrived at the site</li>
+      <li>what you click on while you visit the site</li>
+      <li>the device and browser you use</li>
+    </ul>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption">
+        Analytics cookies we use
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_ga</th>
+          <td class="govuk-table__cell">
+            Helps us count how many people visit the GOV.UK Design System by
+            telling us if you’ve visited before.
+          </td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_gid</th>
+          <td class="govuk-table__cell">
+            Helps us count how many people visit the GOV.UK Design System by
+            telling us if you’ve visited before.
+          </td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            _gat_UA-[random number]
+          </th>
+          <td class="govuk-table__cell">
+            Used to reduce the number of requests.
+          </td>
+          <td class="govuk-table__cell">1 minute</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="govuk-form-group">
+      <fieldset
+        class="govuk-fieldset js-cookies-page-form-fieldset"
+        id="analytics"
+        hidden=""
+      >
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          Do you want to accept analytics cookies?
+        </legend>
+        <div class="govuk-radios" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <input
+              class="govuk-radios__input"
+              id="radio-analytics"
+              name="analytics"
+              type="radio"
+              value="yes"
+            />
+            <label
+              class="govuk-label govuk-radios__label"
+              for="radio-analytics"
+            >
+              Yes
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input
+              class="govuk-radios__input"
+              id="radio-analytics-2"
+              name="analytics"
+              type="radio"
+              value="no"
+            />
+            <label
+              class="govuk-label govuk-radios__label"
+              for="radio-analytics-2"
+            >
+              No
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <button
+      class="govuk-button js-cookies-form-button"
+      data-module="govuk-button"
+      hidden=""
+    >
+      Save cookie settings
+    </button>
+  </form>
+</div>
+

--- a/tests/functional/cookie_banner.test.mjs
+++ b/tests/functional/cookie_banner.test.mjs
@@ -19,6 +19,13 @@ describe('Cookie banner', () => {
     await page.goto('http://localhost:8888/')
   })
 
+  it('is hidden on the cookies page', async () => {
+    await page.setCookie(cookieParam)
+    await page.goto('http://localhost:8888/cookies/')
+
+    await expect(page).not.toMatchElement('#cookie-banner')
+  })
+
   describe('when JavaScript is disabled', () => {
     it('is hidden', async () => {
       await page.setJavaScriptEnabled(false)

--- a/tests/functional/cookie_banner.test.mjs
+++ b/tests/functional/cookie_banner.test.mjs
@@ -1,0 +1,100 @@
+/* global page */
+
+describe('Cookie banner', () => {
+  // Default cookie
+  const cookieParam = {
+    name: 'analytics_consent',
+    value: 'true',
+    url: 'http://localhost:8888'
+  }
+
+  beforeEach(async () => {
+    await page.deleteCookie({
+      name: cookieParam.name,
+      url: cookieParam.url
+    })
+
+    await page.setJavaScriptEnabled(true)
+
+    await page.goto('http://localhost:8888/')
+  })
+
+  describe('when JavaScript is disabled', () => {
+    it('is hidden', async () => {
+      await page.setJavaScriptEnabled(false)
+
+      // Reload page again
+      await page.reload()
+
+      await expect(page).toMatchElement('#cookie-banner', { visible: false })
+      await expect(page).not.toMatchElement('script[src^="https://www.googletagmanager.com"]', { visible: false })
+    })
+  })
+
+  describe('when JavaScript is enabled', () => {
+    it('is visible if there is no consent cookie', async () => {
+      await expect(page).toMatchElement('#cookie-banner', { visible: true })
+    })
+
+    it('is hidden if the consent cookie version is valid', async () => {
+      await page.setCookie(cookieParam)
+
+      // Reload page again
+      await page.reload()
+
+      await expect(page).toMatchElement('#cookie-banner', { visible: false })
+    })
+  })
+
+  describe('accept button', () => {
+    it('sets the consent cookie and adds the goolgle tag script to the page', async () => {
+      await expect(page.cookies()).resolves.toEqual([])
+      await expect(page).toClick('button', { text: 'Accept analytics cookies' })
+
+      await expect(page.cookies()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: cookieParam.name,
+            value: 'true'
+          })
+        ])
+      )
+
+      await expect(page).toMatchElement('script[src^="https://www.googletagmanager.com"]', { visible: false })
+    })
+
+    it('hides the cookie message', async () => {
+      await expect(page).toClick('button', { text: 'Accept analytics cookies' })
+      await expect(page).toMatchElement('#cookie-banner', { visible: false })
+    })
+  })
+
+  describe('reject button', () => {
+    it('sets the consent cookie', async () => {
+      await expect(page.cookies()).resolves.toEqual([])
+      await expect(page).toClick('button', { text: 'Reject analytics cookies' })
+
+      await expect(page.cookies()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: cookieParam.name,
+            value: 'false'
+          })
+        ])
+      )
+
+      await expect(page).not.toMatchElement('script[src^="https://www.googletagmanager.com"]', { visible: false })
+    })
+
+    it('hides the cookie message', async () => {
+      await expect(page).toClick('button', { text: 'Reject analytics cookies' })
+      await expect(page).toMatchElement('#cookie-banner', { visible: false })
+    })
+  })
+
+  describe('cookies page link', () => {
+    it('leads to the cookies page', async () => {
+      await expect(page).toMatchElement('#cookie-banner [href="/cookies"]', { text: 'How we use cookies' })
+    })
+  })
+})

--- a/tests/functional/cookie_page.test.mjs
+++ b/tests/functional/cookie_page.test.mjs
@@ -1,0 +1,88 @@
+/* global page */
+
+describe('Cookie Page', () => {
+  // Default cookie
+  const cookieParam = {
+    name: 'analytics_consent',
+    value: 'true',
+    url: 'http://localhost:8888'
+  }
+
+  beforeEach(async () => {
+    await page.deleteCookie({
+      name: cookieParam.name,
+      url: cookieParam.url
+    })
+
+    await page.setJavaScriptEnabled(true)
+
+    await page.goto('http://localhost:8888/cookies')
+  })
+
+  describe('when JavaScript is disabled', () => {
+    it('form is hidden', async () => {
+      await page.setJavaScriptEnabled(false)
+      await page.reload()
+
+      await expect(page).toMatchElement('button', { visible: false, text: 'Save cookie settings' })
+      await expect(page).not.toMatchElement('script[src^="https://www.googletagmanager.com"]', { visible: false })
+    })
+  })
+
+  describe('when JavaScript is enabled', () => {
+    it('form is visible', async () => {
+      await expect(page).toMatchElement('button', { visible: true, text: 'Save cookie settings' })
+    })
+
+    it('set to false if the consent cookie is not set to true', async () => {
+      await expect(page).toMatchElement('input[name="analytics"][value="no"]:checked', { visible: true })
+    })
+
+    it('set to true if the consent cookie is set to true', async () => {
+      await page.setCookie(cookieParam)
+      await page.reload()
+
+      await expect(page).toMatchElement('input[name="analytics"][value="yes"]:checked', { visible: true })
+    })
+  })
+
+  describe('selecting yes and submitting form', () => {
+    it('sets consent cookie, adds the google tag script, shows notification banner', async () => {
+      await expect(page.cookies()).resolves.toEqual([])
+      await expect(page).toClick('input[name="analytics"][value="yes"]', { visible: true })
+      await expect(page).toClick('button', { text: 'Save cookie settings' })
+
+      await expect(page.cookies()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: cookieParam.name,
+            value: 'true'
+          })
+        ])
+      )
+
+      await expect(page).toMatchElement('script[src^="https://www.googletagmanager.com"]', { visible: false })
+      await expect(page).toMatchElement('.govuk-notification-banner', { visible: true })
+    })
+  })
+
+  describe('selecting no and submitting form', () => {
+    it('sets consent cookie, shows notification banner', async () => {
+      await expect(page.cookies()).resolves.toEqual([])
+      await expect(page).toClick('input[name="analytics"][value="no"]', { visible: true })
+      await expect(page).toClick('button', { text: 'Save cookie settings' })
+
+      await expect(page.cookies()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: cookieParam.name,
+            value: 'false'
+          })
+        ])
+      )
+
+      await expect(page).not.toMatchElement('script[src^="https://www.googletagmanager.com"]', { visible: false })
+      await expect(page).toMatchElement('.govuk-notification-banner', { visible: true })
+    })
+  })
+})


### PR DESCRIPTION
# Adding Google analytics to the product pages

[First trello card](https://trello.com/c/S3oafmnN/697-add-google-tag-to-the-product-pages)
[Second trello card](https://trello.com/c/BpmIEHIT/696-add-ga-consent-mechanism-to-the-product-pages)

[Copy document](https://docs.google.com/document/d/1oMUTedN38L484HQO7-PHI-dg79tDb-uzDrU2oXKQJoo/edit#heading=h.k3djl5u06erz)

This PR adds a consent mechanism - cookie banner and page and google tag manager to the product pages.

It's inspired by others work on these sites: 
- https://github.com/alphagov/govuk-design-system
- https://github.com/alphagov/govuk-developer-docs/commit/b11a8d32960496553b646427ccac693444cd69ce

The requirements stated that:
- we can't just relay on google analytics standard events, we must push events to the tag manager data layer following a set schema
- we shouldn't rely on google tag manager consent mode. The tag manager script should not be loaded at all if the visitor hasn't consented to analytics cookies

Cookie Banner:
A screenshot of the cookie banner:
![image](https://github.com/alphagov/forms-product-page/assets/11035856/1d91686d-8950-4c8d-a4c3-40fc5c0682c2)

Cookie Page
A screenshot of the cookie page:
![image](https://github.com/alphagov/forms-product-page/assets/11035856/2ab0763c-5a6b-44dd-9730-a5ddf812dbcd)

Stuff still to do:
- test in staging
- improve a few of the tests - I just want to get this over the line at this point and I've done quite a bit of x-browser testing
- update the privacy policy page - this will be another PR