### PR TITLE
Update the privacy policy to cover analytics

### DIFF
--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -59,15 +59,14 @@ layout: govuk
   </li>
 </ul>
 <p>
-  We collect this information in system logs. These logs are stored in Amazon
-  Web Services in Ireland.
+  We collect this information in system logs. These logs are stored in Amazon Web
+  Services in the UK.
 </p>
 <p>
   We move some of this information to our security and network monitoring tools
-  in Ireland and the USA which are provided by companies acting as our data
+  in the USA which are provided by companies acting as our data
   processors.
 </p>
-
 <p>
   We may also use this information to produce anonymised reports about the
   GOV.UK Forms service. This helps us understand where we can make improvements.
@@ -148,7 +147,50 @@ layout: govuk
   court order, or to prevent fraud or other crime.
 </p>
 
+<h2 class="govuk-heading-m">
+  Performance analysis
+</h2>
+
+<p>
+  We also carry out performance analysis to see how you use the GOV.UK
+  Forms website and how well the site performs on your device during your
+  visit — we do this to make sure it’s meeting the needs of its users and
+  to improve it.
+</p>
+
+<p>If you provide your consent, we collect the following information:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>your IP address</li>
+  <li>the pages you visit on the GOV.UK Forms website</li>
+  <li>how long you spend on each page</li>
+  <li>how you got to the site</li>
+  <li>what you click on while you’re visiting the site</li>
+</ul>
+
+<p>
+  The legal basis for performing web analytics is your consent. You will be
+  asked for your consent when first landing on this website. If you do not give
+  your consent, you will still be able to use the page. If you do give it and
+  change your mind, you can update your cookie settings.
+</p>
+
 <h2 class="govuk-heading-m">Cookies</h2>
+
+<p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+
+<p>We use cookies to:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>collect information about how you use this website</li>
+  <li>make GOV.UK Forms work</li>
+</ul>
+
+<p>
+  Our mailing list supplier also uses cookies on the sign up page for our mailing list.
+  For more information you can <a href="/cookies">read about the cookies we use</a>.
+</p>
+
 <p>
   We don’t use any cookies on the GOV.UK Forms website. However, Mailchimp uses
   cookies on the sign up page for our mailing list. We also use cookies to make
@@ -166,6 +208,11 @@ layout: govuk
 </ul>
 
 <p>This means that we will only hold your personal data for one year.</p>
+
+<p>
+  If you consent to analytics cookies on the GOV.UK Forms website, your
+  personal data will be retained for 14 months.
+</p>
 
 <p>
   If you have a GOV.UK Forms account, your personal data will be retained while


### PR DESCRIPTION
Adding Google analytics to the product pages changes our cookie policy and privacy policy.

This commit updates the privacy policy to cover the use of analytics.

Trello: https://trello.com/c/GuNfSroW/880-update-privacy-policy-with-data-well-collect-if-you-consent-to-analytics

Because the [analytics branch](https://github.com/alphagov/forms-product-page/pull/29) can't be deployed without this change, this PR is merging into that one.