### PR TITLE
Set consent-cookie path

### DIFF
--- a/source/javascripts/services/cookie.mjs
+++ b/source/javascripts/services/cookie.mjs
@@ -25,5 +25,5 @@ export function loadConsentStatus () {
 export function saveConsentStatus (consent, date) {
   date = date || new Date()
   date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000))
-  document.cookie = COOKIE_NAME + '=' + consent + '; expires=' + date.toGMTString()
+  document.cookie = COOKIE_NAME + '=' + consent + '; expires=' + date.toGMTString() + '; path=/'
 }

--- a/source/javascripts/services/cookie.test.mjs
+++ b/source/javascripts/services/cookie.test.mjs
@@ -42,13 +42,13 @@ describe('Cookie', () => {
     it('writes the correct value to the cookie when given true', () => {
       const fixedTestDate = new Date(2023, 1, 1, 0, 0, 0, 0)
       saveConsentStatus(true, fixedTestDate)
-      expect(window.document.cookie).toBe('analytics_consent=true; expires=Thu, 01 Feb 2024 00:00:00 GMT')
+      expect(window.document.cookie).toBe('analytics_consent=true; expires=Thu, 01 Feb 2024 00:00:00 GMT; path=/')
     })
 
     it('writes the correct value to the cookie when given false', () => {
       const fixedTestDate = new Date(2023, 1, 1, 0, 0, 0, 0)
       saveConsentStatus(false, fixedTestDate)
-      expect(window.document.cookie).toBe('analytics_consent=false; expires=Thu, 01 Feb 2024 00:00:00 GMT')
+      expect(window.document.cookie).toBe('analytics_consent=false; expires=Thu, 01 Feb 2024 00:00:00 GMT; path=/')
     })
   })
 

--- a/tests/functional/cookie_banner.test.mjs
+++ b/tests/functional/cookie_banner.test.mjs
@@ -5,7 +5,8 @@ describe('Cookie banner', () => {
   const cookieParam = {
     name: 'analytics_consent',
     value: 'true',
-    url: 'http://localhost:8888'
+    url: 'http://localhost:8888',
+    path: '/'
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
Cookies are set with a path value which defaults to the current page. This meant that when consent was granted or denied on different pages, the cookie wasn't read on others.

This is fixed by setting the path to '/'. This is ok because the site is hosted on 'https://www.forms.service.gov.uk/'