### PR TITLE
add basic Dockerfile for rails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM ruby:3.2.2-alpine3.17@sha256:b529c297be08b526c03d9f3d6911e13b15be7b9e25b992f4584e9208108bb132 AS build
+
+WORKDIR /app
+
+RUN apk update
+RUN apk upgrade --available
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18 npm git python3 
+RUN adduser -D ruby
+RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
+
+USER ruby
+
+COPY --chown=ruby:ruby Gemfile* ./
+RUN gem install bundler -v 2.4.10
+RUN bundle config set --local without development:test \
+  && bundle config set --local jobs "$(nproc)"
+
+RUN bundle install
+
+COPY --chown=ruby:ruby package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+ENV RAILS_ENV="${RAILS_ENV:-production}" \
+    PATH="${PATH}:/home/ruby/.local/bin" \
+    USER="ruby" 
+
+COPY --chown=ruby:ruby . .
+
+FROM ruby:3.2.2-alpine3.17@sha256:b529c297be08b526c03d9f3d6911e13b15be7b9e25b992f4584e9208108bb132 AS app
+
+ENV RAILS_ENV="${RAILS_ENV:-production}" \
+    PATH="${PATH}:/home/ruby/.local/bin" \
+    USER="ruby" \
+    SECRET_KEY_BASE="dummyvalue"
+
+WORKDIR /app
+
+RUN apk update
+RUN apk upgrade --available
+RUN apk add libc6-compat openssl-dev libpq tzdata
+
+RUN adduser -D ruby
+RUN chown ruby:ruby -R /app
+
+USER ruby
+
+COPY --chown=ruby:ruby bin/ ./bin
+RUN chmod 0755 bin/*
+
+COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
+COPY --chown=ruby:ruby --from=build /app /app
+
+EXPOSE 3000
+
+CMD ["/bin/sh", "-o", "xtrace", "-c", "rails s -b 0.0.0.0"]


### PR DESCRIPTION
This is a first basic dockerfile for the product pages rails app - at the moment the app just has a ping endpoint, so we'll continue to add to this dockerfile as the app develops. 

To review this PR, in the root of `forms-product-page`:
- `docker build . -t rails_docker:1`
- `docker run -p 3000:3000 rails_docker:1`
- `curl http://localhost:3000/ping`
- you should see 'PONG' in return