### PR TITLE
Add missing updates to privacy notice for analytics

### DIFF
--- a/source/privacy.html.erb
+++ b/source/privacy.html.erb
@@ -5,7 +5,7 @@ layout: govuk
 
 <h1 class="govuk-heading-xl">Privacy notice: how we use your data</h1>
 
-<p>Last updated: 16 September 2022</p>
+<p>Last updated: 10 July 2023</p>
 
 <p>
   GOV.UK Forms lets UK government teams create online forms to collect
@@ -189,13 +189,6 @@ layout: govuk
 <p>
   Our mailing list supplier also uses cookies on the sign up page for our mailing list.
   For more information you can <a href="/cookies">read about the cookies we use</a>.
-</p>
-
-<p>
-  We don’t use any cookies on the GOV.UK Forms website. However, Mailchimp uses
-  cookies on the sign up page for our mailing list. We also use cookies to make
-  the GOV.UK Forms platform work. For more information you can
-  <a href="/cookies">read about the cookies we use</a>.
 </p>
 
 <h2 class="govuk-heading-m">How long we keep your data</h2>


### PR DESCRIPTION
A couple of small updates that were missed when the privacy notice was updated for analytics: 
- updating the 'last updated' date
- removing some content that was no longer accurate

Trello: https://trello.com/c/ucv5LNgG/970-review-and-correct-privacy-and-cookies-notices-for-analytics-updates