### PR TITLE
Fix docker asset build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,13 @@ ENV RAILS_ENV="${RAILS_ENV:-production}" \
 
 COPY --chown=ruby:ruby . .
 
+# you can't run rails commands like assets:precompile without a secret key set
+# even though the command doesn't use the value itself
+RUN SECRET_KEY_BASE=dummyvalue rails assets:precompile
+
+# Remove devDependencies once assets have been built
+RUN npm ci --ignore-scripts --only=production
+
 FROM ruby:3.2.2-alpine3.17@sha256:b529c297be08b526c03d9f3d6911e13b15be7b9e25b992f4584e9208108bb132 AS app
 
 ENV RAILS_ENV="${RAILS_ENV:-production}" \

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,9 @@ gem "rails", "~> 7.0.6"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+# Alpine requires these to build the assets
+gem "tzinfo"
+gem "tzinfo-data"
 
 # For compiling our frontend assets
 gem "vite_rails", "~> 3.0"


### PR DESCRIPTION
Assets are not being built in the current Dockerfile, which results in errors at runtime about assets not being found.

To fix this, the rails assets:precompile command in the build section of the Dockerfile.

We also need to add `tzinfo` and `tzinfo-data` gems as alpine doesn't include these.

This matches forms-admin.

To check this fixes the issue, run:
```
docker build -t product-test .
docker run -e RAILS_LOG_TO_STDOUT=true -e RAILS_ENV=production -e RAILS_SERVE_STATIC_FILES=true -p 3007:3000 --rm product-test
```
