### PR TITLE
Align Configuration With Other Apps

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -17,7 +17,7 @@ Config.setup do |config|
 
   # Load environment variables from the `ENV` object and override any settings defined in files.
   #
-  # config.use_env = false
+  config.use_env = true
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
@@ -32,7 +32,7 @@ Config.setup do |config|
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
   # using dots in variable names might not be allowed (eg. Bash).
   #
-  # config.env_separator = '.'
+  config.env_separator = "__"
 
   # Ability to process variables names:
   #   * nil  - no change


### PR DESCRIPTION
Use the settings.yaml and set the separator as `__`.


### NOTES ###
Deployed this to dev and we've seen the exception come through to Sentry (note that the sentry settings were not being set because the initialisation of the settings gem was not configured correctly).