### PR TITLE
add persistent timout of 75 to puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,6 +24,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
+# Specifies the persistent timeout to be higher than AWS ALB default of 60
+# this is to prevent 502s
+persistent_timeout ENV.fetch("RAILS_PERSISTENT_TIMEOUT", 75)
+
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
 # the concurrency of the application would be max `threads` * `workers`.


### PR DESCRIPTION
### What problem does this pull request solve?


This PR adds a persistent_time of 75 to the puma config so that it is higher than the ALB idle time as this was causing 502s

