### PR TITLE
Change default port

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT", 3000)
+port ENV.fetch("PORT", 3002)
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

To avoid port collisions with the forms-admin app [[1]], change the default port from 3000 to 3002.

[1]: https://github.com/alphagov/forms-admin/blob/545be0398d190c29b4bacbec6ac4955864595b23/config/puma.rb#L18

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?