### PR TITLE
Update privacy notice for support form

### DIFF
--- a/app/views/pages/privacy.erb
+++ b/app/views/pages/privacy.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-xl">Privacy notice: how we use your data</h1>
 
-<p>Last updated: 10 July 2023</p>
+<p>Last updated: 18 September 2023</p>
 
 <p>
   GOV.UK Forms lets UK government teams create online forms to collect
@@ -121,8 +121,8 @@
 </p>
 
 <p>
-  If you email us about GOV.UK Forms we’ll collect your email address and any
-  other personal information you choose to include in your email.
+  If you contact us about GOV.UK Forms we’ll collect your name, email address and any
+  other personal information you choose to include in your message.
 </p>
 
 <p>The legal basis for processing this data is that it’s necessary:</p>
@@ -184,7 +184,6 @@
 </ul>
 
 <p>
-  Our mailing list supplier also uses cookies on the sign up page for our mailing list.
   For more information you can <a href="/cookies">read about the cookies we use</a>.
 </p>
 


### PR DESCRIPTION
### What problem does this pull request solve?

Update to cover personal information collected if you contact us. The privacy notice already covered contacting us by email, but now will also cover contacting us through the support form we plan to add to the product site. I have used the non specific language of 'contacting us' to cover both of these routes. 

I've also removed a line about cookies that we don't need on this page as we cover it in the cookies page. 

Trello: https://trello.com/c/ChYe4oVe/1030-review-and-update-the-privacy-policy-to-reflect-the-new-support-form

### Things to consider when reviewing
- Did Hannah do it all correctly? Let her know if not cos she wants to be better at github!
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
