### PR TITLE
Update cookies and privacy pages for Auth0

### DIFF
--- a/app/views/pages/cookies.erb
+++ b/app/views/pages/cookies.erb
@@ -39,7 +39,10 @@
   <li>make GOV.UK Forms work</li>
 </ul>
 
-<p>Our mailing list supplier also uses cookies on the sign up page for our mailing list.</p>
+<p>
+  Our mailing list supplier uses cookies on the sign up page for our mailing list. And our authentication 
+  supplier uses cookies to authenticate you when you sign in to the GOV.UK Forms product. 
+</p>
 
 <p>Find out <a href="https://ico.org.uk/your-data-matters/online/cookies/">how to manage cookies</a>.</p>
 
@@ -212,4 +215,13 @@
     </tr>
   </tbody>
 </table>
+
+<h2 class="govuk-heading-l">Cookies when you sign in to GOV.UK Forms</h2>
+
+<p>
+  We use Auth0 to authenticate you when you sign in to the GOV.UK Forms product. 
+  Auth0 uses cookies to make this work. For more information you can 
+  <a href="https://auth0.com/docs/manage-users/cookies/authentication-api-cookies">read about Auth0 cookies</a>.
+</p>
+
 </div>

--- a/app/views/pages/privacy.erb
+++ b/app/views/pages/privacy.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-xl">Privacy notice: how we use your data</h1>
 
-<p>Last updated: 18 September 2023</p>
+<p>Last updated: 22 September 2023</p>
 
 <p>
   GOV.UK Forms lets UK government teams create online forms to collect
@@ -84,6 +84,12 @@
 <p>
   We use this data to ensure that only legitimate users of GOV.UK Forms can use
   it to create forms.
+</p>
+
+<p>
+  We use the supplier, Auth0, to authenticate your email address when you sign in 
+  to GOV.UK Forms. This involves us sharing your email address with Auth0 as a data 
+  processor. For more information you can <a href="https://auth0.com/docs/secure/data-privacy-and-compliance/data-processing">read about how Auth0 processes data</a>. 
 </p>
 
 <p>


### PR DESCRIPTION
### What problem does this pull request solve?

We're switching to using Auth0 for authentication. They use cookies to make this work. They also get access to each user's email address. So we need to add some information about this to our cookies statement and privacy notice.

Not to be merged until we switch to Auth0.

Trello card: https://trello.com/c/HPTRv42o/839-draft-change-to-cookies-privacy-notice-to-include-auth0-cookies-and-data

### Things to consider when reviewing

- Did Hannah do everything right/well? Let her know if not!
- Are there any straight quotes that should be curly? 
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
