### PR TITLE
Hide support form from search engines

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,13 @@ module ApplicationHelper
   def set_page_description(description)
     content_for(:description) { description.html_safe }
   end
+
+  def page_robots
+    directive = content_for(:robots)
+    tag.meta(name: "robots", content: directive) if directive.present?
+  end
+
+  def set_page_robots(directive)
+    content_for(:robots) { directive }
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <title><%= page_title %></title>
 
     <%= page_description %>
+    <%= page_robots %>
 
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>

--- a/app/views/support/form.html.erb
+++ b/app/views/support/form.html.erb
@@ -1,4 +1,6 @@
 <% set_page_title(title_with_error_prefix(t("page_titles.support.#{@support_form.i_need_help_with}"), error: @support_form.errors.any?)) %>
+<% set_page_robots("noindex") %>
+
 <% content_for :back_link, govuk_back_link(href: support_path) %>
 
 <%= form_with model: @support_form, url: false do |f| %>

--- a/app/views/support/support.html.erb
+++ b/app/views/support/support.html.erb
@@ -1,5 +1,6 @@
 <% set_page_title(title_with_error_prefix(t("page_titles.support.support"), error: @support_form.errors.any?)) %>
 <% set_page_description(t(".page_description")) %>
+<% set_page_robots("noindex") %>
 
 <%= form_with model: @support_form, url: new_support_message_path do |f| %>
   <% f.govuk_error_summary %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -36,4 +36,22 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.content_for(:description)).to eq("New Description")
     end
   end
+
+  describe "#page_robots" do
+    it "returns the meta tag with robots directive if robots is set" do
+      helper.content_for(:robots, "test")
+      expect(helper.page_robots).to eq('<meta name="robots" content="test">')
+    end
+
+    it "returns nil if robots is not set" do
+      expect(helper.page_robots).to be_nil
+    end
+  end
+
+  describe "#set_page_robots" do
+    it "sets the robots directive for the page" do
+      helper.set_page_robots("noindex")
+      expect(helper.content_for(:robots)).to eq("noindex")
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/M1kGMpxU <!-- link -->

We've been discussing in our feature team the option of stopping our support page being indexed by search engines [[1]]; this is because members of the public often come across our page when searching for help with government services, but as a team we're only able to help with queries from people who want to build forms. This came up again recently when I was talking to GOV.UK Notify, who have done the same thing [[2]].

This PR adds a `noindex` robots directive to the support form pages, in the manner documented by Google [[3]] and also used by Notify [[2]].

If you're reviewing this change and feel like this is a bad idea, feel free to say so, either on here or on Slack :D

[1]: https://gds.slack.com/archives/C05P47JF05Q/p1695199556948639
[2]: https://github.com/alphagov/notifications-admin/pull/3462
[3]: https://developers.google.com/search/docs/crawling-indexing/block-indexing

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- **Do you think this change is a good idea?**
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?