### PR TITLE
Add sign in link and get started page to header navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,7 @@
   <%= render(HeaderComponent::View.new(
     phase_name: "beta",
     navigation_items: [
+      {text: "Get started", href: get_started_path},
       {text: "Features", href: features_path},
       {text: "Support", href: support_path},
       {text: "Sign in", href: Settings.forms_admin.base_url},

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,7 @@
     navigation_items: [
       {text: "Features", href: features_path},
       {text: "Support", href: support_path},
+      {text: "Sign in", href: Settings.forms_admin.base_url},
     ]
   )) %>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -10,13 +10,7 @@
           Create an accessible online form in minutes without needing technical knowledge.
         </p>
 
-        <p class="hero__paragraph">
-          GOV.UK Forms is in development with selected government partners. You
-          can register to get a notification when it’s available for all of
-          central government.
-        </p>
-
-        <%= govuk_start_button text: "Register your interest", href: mailing_list_path, classes: "app-button--inverted" %>
+        <%= govuk_start_button text: "Find out if you can use GOV.UK Forms", href: get_started_path, classes: "app-button--inverted" %>
 
       </div>
       <div class="hero__aside-image">

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -1,0 +1,11 @@
+# spec/views/layouts/application.html.erb_spec.rb
+
+require "rails_helper"
+
+RSpec.describe "layouts/application", type: :view do
+  it "renders the layout with a link to sign in to forms-admin in the header" do
+    render
+
+    expect(rendered).to have_link("Sign in", href: Settings.forms_admin.base_url)
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

We want users who visit our product page to be able to sign up to GOV.UK Forms for a trial account, or sign in to their existing account.

This PR adds a link to sign in to forms-admin to the header navigation, and also directs new users to the new get started page (added in #116) from the home page call to action.

Trello card: https://trello.com/c/xebzfFm9, https://trello.com/c/4p6qkzvc

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

<details><summary>Screenshot</summary>
<p>

<img width="1352" alt="Screenshot of GOV.UK Forms product page, with Get Started and Sign in links in header, and updated call to action" src="https://github.com/alphagov/forms-product-page/assets/503614/ab515f04-c62a-40d6-9206-31612fca8d22">


</p>
</details> 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
