### PR TITLE
Add URL for forms-admin to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,7 @@
+forms_admin:
+  # URL to form-admin
+  base_url: http://localhost:3000
+
 # When set to true, any system tests will run Chrome normally rather than in headless mode.
 show_browser_during_tests: false
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In alphagov/forms-deploy#423 we added `SETTINGS__FORMS_ADMIN__BASE_URL` to the AWS environment variables for this app; this PR adds this config variable to `config/settings.yml` so we can access the value and have a sensible default if it is not set.

This PR pulls from the draft changes in #111 by @jamie-o-wilkinson, so I can use them before that PR is merged.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?