### PR TITLE
Refactor header to use view component from `govuk_components` gem

### DIFF
--- a/app/components/header_component/view.rb
+++ b/app/components/header_component/view.rb
@@ -1,0 +1,37 @@
+module HeaderComponent
+  class View < ViewComponent::Base
+    attr_accessor :navigation_items, :phase_name
+
+    def initialize(navigation_items: [], phase_name: nil)
+      super
+      @navigation_items = navigation_items
+      @phase_name = phase_name
+    end
+
+    def call
+      govuk_header(homepage_url:) do |header|
+        header.with_product_name(**product_name_with_tag)
+
+        navigation_items.each do |item|
+          header.with_navigation_item(**item.to_h)
+        end
+      end
+    end
+
+  private
+
+    def homepage_url
+      root_path
+    end
+
+    def product_name_with_tag
+      {
+        name: "#{I18n.t('header.product_name')} #{product_tag}".html_safe,
+      }
+    end
+
+    def product_tag
+      govuk_tag(text: phase_name, classes: %w[govuk-phase-banner__content__tag]).html_safe
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,65 +37,13 @@
     <%= render partial: "pages/cookie_banner" %>
   <% end %>
 
-  <header
-      class="govuk-header"
-      role="banner"
-      data-module="govuk-header"
-      id="top"
-    >
-      <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-          <a href="/" class="govuk-header__link govuk-header__link--homepage">
-            <span class="govuk-header__logotype">
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                class="govuk-header__logotype-crown"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 132 97"
-                height="30"
-                width="36"
-              >
-                <path
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                  d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
-                ></path>
-              </svg>
-              <span class="govuk-header__logotype-text"> GOV.UK </span>
-            </span>
-            <span class="govuk-header__product-name">
-              Forms
-              <strong class="govuk-tag govuk-phase-banner__content__tag">
-                beta
-              </strong>
-            </span>
-          </a>
-        </div>
-        <div class="govuk-header__content">
-          <nav aria-label="Menu" class="govuk-header__navigation">
-            <button
-              type="button"
-              class="govuk-header__menu-button govuk-js-header-toggle"
-              aria-controls="navigation"
-              aria-label="Show or hide menu"
-              hidden
-            >
-              Menu
-            </button>
-
-            <ul id="navigation" class="govuk-header__navigation-list">
-              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(features_path) %>">
-                <%= link_to 'Features', features_path, class: "govuk-header__link" %>
-              </li>
-              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(support_path) %>">
-                <%= link_to 'Support', support_path, class: "govuk-header__link" %>
-              </li>
-            </ul>
-          </nav>
-        </div>
-      </div>
-    </header>
+  <%= render(HeaderComponent::View.new(
+    phase_name: "beta",
+    navigation_items: [
+      {text: "Features", href: features_path},
+      {text: "Support", href: support_path},
+    ]
+  )) %>
 
     <% if content_for?(:main) %>
       <%= yield(:main) %>

--- a/config/initializers/govuk_components.rb
+++ b/config/initializers/govuk_components.rb
@@ -1,0 +1,6 @@
+Govuk::Components.configure do |config|
+  # Fix default header ARIA labels to match GOV.UK Frontend 4.x
+  # TODO: Remove these lines when a fix for x-govuk/govuk-components#460 has been released
+  config.default_header_navigation_label = "Menu"
+  config.default_header_menu_button_label = "Show or hide menu"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,5 @@
 ---
 en:
   continue: Continue
+  header:
+    product_name: Forms

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -1,5 +1,9 @@
 require "rails_helper"
 
+def normalize_html(html)
+  Nokogiri::XML(html, &:noblanks).to_xhtml(indent: 2)
+end
+
 RSpec.describe HeaderComponent::View, type: :component do
   let(:navigation_items) do
     [
@@ -41,6 +45,74 @@ RSpec.describe HeaderComponent::View, type: :component do
           ).to match_selector ".govuk-header__navigation-item--active"
         end
       end
+    end
+  end
+
+  describe "render" do
+    it "outputs HTML matching our existing header", skip: "expected to fail due to formatting differences" do
+      # rubocop:disable Layout/HeredocIndentation
+      expect(normalize_html(rendered_content)).to eq normalize_html(<<~HTML)
+  <header
+      class="govuk-header"
+      role="banner"
+      data-module="govuk-header"
+      id="top"
+    >
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                class="govuk-header__logotype-crown"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 132 97"
+                height="30"
+                width="36"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+                ></path>
+              </svg>
+              <span class="govuk-header__logotype-text"> GOV.UK </span>
+            </span>
+            <span class="govuk-header__product-name">
+              Forms
+              <strong class="govuk-tag govuk-phase-banner__content__tag">
+                beta
+              </strong>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <nav aria-label="Menu" class="govuk-header__navigation">
+            <button
+              type="button"
+              class="govuk-header__menu-button govuk-js-header-toggle"
+              aria-controls="navigation"
+              aria-label="Show or hide menu"
+              hidden
+            >
+              Menu
+            </button>
+
+            <ul id="navigation" class="govuk-header__navigation-list">
+              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(features_path) %>">
+                <%= link_to 'Features', features_path, class: "govuk-header__link" %>
+              </li>
+              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(support_path) %>">
+                <%= link_to 'Support', support_path, class: "govuk-header__link" %>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+      HTML
+      # rubocop:enable Layout/HeredocIndentation
     end
   end
 end

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -49,19 +49,20 @@ RSpec.describe HeaderComponent::View, type: :component do
   end
 
   describe "render" do
-    it "outputs HTML matching our existing header", skip: "expected to fail due to formatting differences" do
+    # TODO: fix this test once x-govuk/govuk-components#461 has been released
+    it "outputs HTML matching our existing header", skip: "expected to viewBox bug" do
       # rubocop:disable Layout/HeredocIndentation
       expect(normalize_html(rendered_content)).to eq normalize_html(<<~HTML)
   <header
-      class="govuk-header"
       role="banner"
       data-module="govuk-header"
-      id="top"
+      class="govuk-header"
     >
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
-          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+          <a class="govuk-header__link govuk-header__link--homepage" href="/">
             <span class="govuk-header__logotype">
+      <!--[if gt IE 8]><!-->
               <svg
                 aria-hidden="true"
                 focusable="false"
@@ -77,34 +78,28 @@ RSpec.describe HeaderComponent::View, type: :component do
                   d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
                 ></path>
               </svg>
-              <span class="govuk-header__logotype-text"> GOV.UK </span>
+      <!--<![endif]-->
+              <span class="govuk-header__logotype-text">GOV.UK</span>
             </span>
-            <span class="govuk-header__product-name">
-              Forms
-              <strong class="govuk-tag govuk-phase-banner__content__tag">
-                beta
-              </strong>
-            </span>
+            <span class="govuk-header__product-name">Forms <strong class="govuk-tag govuk-phase-banner__content__tag">beta</strong></span>
           </a>
         </div>
         <div class="govuk-header__content">
-          <nav aria-label="Menu" class="govuk-header__navigation">
+          <nav class="govuk-header__navigation" aria-label="Menu">
             <button
               type="button"
               class="govuk-header__menu-button govuk-js-header-toggle"
+              hidden="hidden"
               aria-controls="navigation"
               aria-label="Show or hide menu"
-              hidden
-            >
-              Menu
-            </button>
+            >Menu</button>
 
             <ul id="navigation" class="govuk-header__navigation-list">
-              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(features_path) %>">
-                <%= link_to 'Features', features_path, class: "govuk-header__link" %>
+              <li class="govuk-header__navigation-item">
+                <a class="govuk-header__link" href="/features">Features</a>
               </li>
-              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(support_path) %>">
-                <%= link_to 'Support', support_path, class: "govuk-header__link" %>
+              <li class="govuk-header__navigation-item">
+                <a class="govuk-header__link" href="/support">Support</a>
               </li>
             </ul>
           </nav>

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe HeaderComponent::View, type: :component do
+  let(:navigation_items) do
+    [
+      { text: "Features", href: "/features" },
+      { text: "Support", href: "/support" },
+    ]
+  end
+
+  let(:phase_name) { "beta" }
+
+  let(:header_component) do
+    described_class.new(navigation_items:, phase_name:)
+  end
+
+  let(:current_page) { "/" }
+
+  before do
+    with_request_url current_page do
+      render_inline header_component
+    end
+  end
+
+  describe "call" do
+    context "when on the homepage" do
+      it "renders the navigation items as inactive" do
+        expect(page).not_to have_selector(
+          ".govuk-header__navigation-item.govuk-header__navigation-item--active",
+        )
+      end
+    end
+
+    %w[features support].each do |view|
+      context "when on the #{view} page" do
+        let(:current_page) { "/#{view}" }
+
+        it "renders the #{view} navigation item as active" do
+          expect(
+            page.find(".govuk-header__navigation-item", text: view.capitalize),
+          ).to match_selector ".govuk-header__navigation-item--active"
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
+require "view_component/test_helpers"
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
@@ -53,4 +55,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/4p6qkzvc <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to change the header for the above ticket, and also for PR #111, I thought I'd take the opportunity to refactor the application.html.erb layout to use a view component instead of hardcoded HTML.

Following the examples from forms-admin and form-runner [[1], [2]], I've created a new view component that calls the `govuk_header` component from the `govuk_components` gem [[3]]. Unfortunately I couldn't just lift and shift the code from either app; for various reasons we've ended up with slightly different headers in each of our apps :sweat_smile:. I was able to re-use enough though that when we have time to consolidate it should be straight-forward to mash all the different implementations together.

Oh, also note that when I was doing this I tried to make sure that the HTML we ended up with matched the original as much as possible, but I ended up finding that wasn't possible... see commit messages for details.

[1]: https://github.com/alphagov/forms-admin/tree/ec13c63185cca12a913964d3adbbd9f3c86b61f3/app/components/header_component
[2]: https://github.com/alphagov/forms-runner/tree/f091d863a384c6f19346d9de6e36f10d354a2182/app/components/form_header_component
[3]: https://govuk-components.netlify.app/components/header/

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?