### PR TITLE
Redirect users to sign up route from get started page

### DIFF
--- a/app/views/pages/get_started.html.erb
+++ b/app/views/pages/get_started.html.erb
@@ -29,7 +29,7 @@
 
 <p>You’ll need your government email address to create a trial account.</p>
 
-<%= govuk_start_button text: "Create a trial account", href: Settings.forms_admin.base_url %>
+<%= govuk_start_button text: "Create a trial account", href: "#{Settings.forms_admin.base_url}/sign-up" %>
 
 <h2 class="govuk-heading-l">Upgrading to an editor account</h2>
 

--- a/spec/views/pages/get_started.html.erb_spec.rb
+++ b/spec/views/pages/get_started.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe "pages/get_started.html.erb", type: :view do
+  before do
+    allow(Settings.forms_admin).to receive(:base_url).and_return("forms-admin.test")
+
+    render template: "pages/get_started"
+  end
+
+  it "has a call to action encouraging users to create an account in forms-admin" do
+    expect(rendered).to have_selector(".govuk-button--start") do |start_button|
+      expect(start_button).to match_selector(
+        :link,
+        "Create a trial account",
+        href: "forms-admin.test/sign-up",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/4p6qkzvc/1175-product-site-create-get-started-page-so-people-can-create-trial-accounts

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This was missed in #116, the call to action on the get started page should point users to the 'Create an account' journey in forms-admin, rather than the 'Sign in' journey.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?