### PR TITLE
Remove workarounds for govuk_components header

### DIFF
--- a/config/initializers/govuk_components.rb
+++ b/config/initializers/govuk_components.rb
@@ -1,6 +1,0 @@
-Govuk::Components.configure do |config|
-  # Fix default header ARIA labels to match GOV.UK Frontend 4.x
-  # TODO: Remove these lines when a fix for x-govuk/govuk-components#460 has been released
-  config.default_header_navigation_label = "Menu"
-  config.default_header_menu_button_label = "Show or hide menu"
-end

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe HeaderComponent::View, type: :component do
   end
 
   describe "render" do
-    # TODO: fix this test once x-govuk/govuk-components#461 has been released
-    it "outputs HTML matching our existing header", skip: "expected to viewBox bug" do
+    it "outputs HTML matching our existing header" do
       # rubocop:disable Layout/HeredocIndentation
       expect(normalize_html(rendered_content)).to eq normalize_html(<<~HTML)
   <header


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

govuk_components 4.1.2 was released with fixes for issues x-govuk/govuk-components#460 and x-govuk/govuk-components#461, and we're now using the version with the fixes in this app (see Dependabot PR #123), so we can remove our workaround and get our tests passing properly.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?