### PR TITLE
Add warning to 'get started' page about department restrictions

### DIFF
--- a/app/views/pages/get_started.html.erb
+++ b/app/views/pages/get_started.html.erb
@@ -19,17 +19,14 @@
 
 <p>
   With a trial account you will not be able to make your forms live, but you’ll
-  be able to try out the form builder and preview your forms.
-</p>
-
-<p>
-  If GOV.UK Forms meets your needs, you’ll be able to ask for your account to
-  be upgraded so you can make your forms live.
+  be able to try out the form builder and see how it works.
 </p>
 
 <p>You’ll need your government email address to create a trial account.</p>
 
 <%= govuk_start_button text: "Create a trial account", href: "#{Settings.forms_admin.base_url}/sign-up" %>
+
+<p>Some departments are restricting who can create an account from their organisation. We’ll tell you if this affects you.</p>
 
 <h2 class="govuk-heading-l">Upgrading to an editor account</h2>
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/iDUTqGVm/1223-update-product-page-content-for-users-from-organisations-which-may-restrict-their-access

Added a warning to set expectations that some people will not be able to create a trial account because their department is restricting access. 

Also:

- removed a line that was duplicative - so the page doesn't get too busy. 
- changed 'and preview your forms' to 'and see how it works' to avoid people thinking they'll be able to see their department's forms as a trial user and because it's less specific to one thing you can do.

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
