### PR TITLE
Remove logging of the Zendesk response body

### DIFF
--- a/app/service/zendesk_ticket_service.rb
+++ b/app/service/zendesk_ticket_service.rb
@@ -39,7 +39,7 @@ private
     if response.is_a? Net::HTTPSuccess
       JSON.parse(response.body)
     else
-      raise "Creating Zendesk ticket failed: #{response.code}: #{response.body}"
+      raise "Creating Zendesk ticket failed: #{response.code}"
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

If there was an error during creation of a Zendesk ticket via the API, we were raising an exception that contained the whole Zendesk response body. This has resulted in two incidents where PII was logged to Sentry, so we are just removing this logging entirely for now. We could look at more nuanced scrubbing of the data in future.

Trello card: https://trello.com/c/8mYIwwKx/1358-sentry-alert-forms-product-page-creating-zendesk-ticket-failed

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
