### PR TITLE
Remove reference to stdout env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,11 +48,6 @@ module FormsProductPage
     # logging use the Logger::Formatter.new.
     config.log_formatter = JsonLogFormatter.new
 
-    if ENV["RAILS_LOG_TO_STDOUT"].present?
-      config.logger = ActiveSupport::Logger.new($stdout)
-      config.logger.formatter = config.log_formatter
-    end
-
     # Lograge is used to format the standard HTTP request logging
     config.lograge.enabled = true
     config.lograge.formatter = Lograge::Formatters::Json.new


### PR DESCRIPTION
This was missed out from removal before [1] as we default to stdout for production environments.

[1]: https://github.com/alphagov/forms-deploy/pull/395
