### PR TITLE
Update features and homepage content

### DIFF
--- a/app/views/pages/features.html.erb
+++ b/app/views/pages/features.html.erb
@@ -1,25 +1,13 @@
 <% set_page_title('How GOV.UK Forms works') %>
-<% set_page_description('The process for creating a form, the features already available and the features we are working on next.') %>
+<% set_page_description('The process for creating a form and the features already available.') %>
 
 <h1 class="govuk-heading-xl">How GOV.UK Forms works</h1>
 <p>
   GOV.UK Forms is a new platform that makes it easy to create accessible online
-  forms for GOV.UK. It’s currently in development with selected government
-  partners.
-</p>
-
-<p class="govuk-inset-text">
-  If you’re interested in using GOV.UK Forms, you can
-  <%= govuk_link_to "register to get a notification when it's available", mailing_list_path %>
-  for all of central government.
+  forms for the GOV.UK website.
 </p>
 
 <h2 class="govuk-heading-l">Creating a form using GOV.UK Forms</h2>
-
-<p>
-  You need to be given access to GOV.UK Forms to use it. In this early stage of
-  development, we’re only working with a limited number of government teams.
-</p>
 
 <p>These are the steps to make a form with GOV.UK Forms.</p>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -155,15 +155,19 @@
           The GOV.UK Forms team
         </h2>
         <p class="govuk-body">
-          GOV.UK Forms is being developed by a team at the Government Digital
-          Service.
+          GOV.UK Forms is built by a team at the Government Digital
+          Service. You can:
         </p>
-        <p class="govuk-body">
-          <a class="govuk-link" href="/support"
-            >Contact the GOV.UK Forms team</a
-          >
-          if you have a question or need help.
-        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <%= govuk_link_to "contact us", support_path %>
+            if you have a question or need help
+          </li>
+          <li>
+            <%= govuk_link_to "subscribe to our mailing list", mailing_list_path %>
+            to get updates about new features
+          </li>
+        </ul>
       </section>
     </div>
   </div>


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:https://trello.com/c/R2dd3YMe/1211-update-the-wording-of-the-mailing-list-registration-page

As we have now launched GOV⁠.⁠UK Forms (Early Access), this updates a reference on the 'Features' page to getting a notification when GOV⁠.⁠UK Forms has launched, and to it being in development with selected government partners.

This also adds a link to the mailing list to the homepage - because the mailing list is no longer the main call to action on the homepage. 

### Things to consider when reviewing

- Did Hannah mess up the ruby links? or the spacing? 
- Does it look right and work right when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
