### PR TITLE
  Add RAILS_LOG_TO_STDOUT Back In

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,8 +49,10 @@ module FormsProductPage
     # logging use the Logger::Formatter.new.
     config.log_formatter = JsonLogFormatter.new
 
-    config.logger = ActiveSupport::Logger.new($stdout)
-    config.logger.formatter = config.log_formatter
+    if ENV["RAILS_LOG_TO_STDOUT"].present?
+      config.logger = ActiveSupport::Logger.new($stdout)
+      config.logger.formatter = config.log_formatter
+    end
 
     # Lograge is used to format the standard HTTP request logging
     config.lograge.enabled = true


### PR DESCRIPTION
  It was wrongly thought the condition around logging to standard out
  only when RAILS_LOG_TO_STDOUT was set could be removed because we
  always want to log to standard out. This isn't correct because during
  testing we do not want to see the application logs.

  This was originally removed as part of commit
  8ac5fac683d8025e323da6f8f91d6cf6a46fe244

### What problem does this pull request solve?

Link to original commit removing this condition: https://github.com/alphagov/forms-product-page/pull/139/commits/8ac5fac683d8025e323da6f8f91d6cf6a46fe244

The logs are no longer shown when running `bundle exec rspec`

Latest CI run: https://github.com/alphagov/forms-product-page/actions/runs/7261377445/job/19782436615?pr=168#step:7:1


- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
