### PR TITLE
Move stdout logging back to prod as the default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,9 +49,6 @@ module FormsProductPage
     # logging use the Logger::Formatter.new.
     config.log_formatter = JsonLogFormatter.new
 
-    config.logger = ActiveSupport::Logger.new($stdout)
-    config.logger.formatter = config.log_formatter
-
     # Lograge is used to format the standard HTTP request logging
     config.lograge.enabled = true
     config.lograge.formatter = Lograge::Formatters::Json.new

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Log to STDOUT by default
+  config.logger = ActiveSupport::Logger.new($stdout)
+    .tap { |logger| logger.formatter = config.log_formatter }
+
   # Do not enable log_tags because it interferes with the
   # json formatting of log_rage. The request_id is already
   # being logged by log_rage.


### PR DESCRIPTION
### What problem does this pull request solve?

Otherwise every environment was getting debug output in the stdout. Also this is closer to how Rails is set up, which hopefully means we have less diversion to help with future upgrades.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
