### PR TITLE
Add AWS application load balancer trace ID to logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
     super
     payload[:host] = request.host
     payload[:request_id] = request.request_id
+    payload[:trace_id] = request.env["HTTP_X_AMZN_TRACE_ID"].presence
     payload[:user_ip] = user_ip(request.env.fetch("HTTP_X_FORWARDED_FOR", ""))
   end
 

--- a/app/lib/lograge/custom_options.rb
+++ b/app/lib/lograge/custom_options.rb
@@ -6,6 +6,7 @@ module Lograge
         h[:user_ip] = event.payload[:user_ip]
         h[:request_id] = event.payload[:request_id]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
+        h[:trace_id] = event.payload[:trace_id] if event.payload[:trace_id]
       end
     end
   end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,6 +1,29 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :request do
+  context "when there is a application load balancer trace ID" do
+    let(:payloads) { [] }
+    let(:payload) { payloads.last }
+
+    let!(:subscriber) do
+      ActiveSupport::Notifications.subscribe("process_action.action_controller") do |_, _, _, _, payload|
+        payloads << payload
+      end
+    end
+
+    before do
+      get root_path, headers: { "HTTP_X_AMZN_TRACE_ID": "Root=1-63441c4a-abcdef012345678912345678" }
+    end
+
+    after do
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "adds the trace ID to the instrumentation payload" do
+      expect(payload).to include(trace_id: "Root=1-63441c4a-abcdef012345678912345678")
+    end
+  end
+
   describe "#up" do
     it "returns http code 200" do
       get rails_health_check_path


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to correlate our Elastic Load Balancer logs with app logs. This is particularly useful when there is a `460` error because the client has closed the connection for taking too long.

This PR adds the `X-Amzn-Trace-Id` header [[1]] to our request logging.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?