### PR TITLE
Fix Vite CommonJS deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "forms-product-page",
   "private": "true",
+  "type": "module",
   "dependencies": {
     "govuk-frontend": "5.2.0"
   },


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/4WGWwZRU/1496-resolve-vite-deprecation-warning

The CommonJS build of Vite will no longer be supported as of v6. 

Fortunately none of the JS files in this repo are CommonJS anyway, so all we need to do to fix this is add `"type": "module"` to our package.json file.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
