### PR TITLE
Remove beta assessment message from humans.txt

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,7 +1,2 @@
 GOV.UK Forms is built by a team at the Government Digital Service in London, 
 Manchester and Bristol. If you'd like to join us, see https://gdscareers.gov.uk/
-
-This week GOV.UK Forms had its Beta assessment. This is a huge milestone for us,
-and we want to shout out our assessment presentation team - thank you to Adam, 
-Anne, Betty, Chris, Dan, Emma, Hannah, Holly, Irina, James, Kelvin, Oliver, and 
-Sylvia! 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->N/A

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We temporarily added a message to the humans.txt file to shout out the team doing the assessment. We've now done the assessment (we passed!) so we can remove the message (we're still grateful to the people involved).

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
