### PR TITLE
Add  /.well-known/security.txt routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
 
   get "/mailing-list" => redirect("https://service.us12.list-manage.com/subscribe?u=cb74eb9a6898b0e5870fede0a&id=451fe4c1e1")
 
+  get "/security.txt.html" => redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
+  get "/.well-known/security.txt.html" => redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
+
   get "/support" => "support#support", as: :support
   post "/support" => "support#new", as: :new_support_message
   get "/support/help-using-forms" => "support#help_using_forms", as: :help_using_forms


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card:[add-well-known-securitytxt](https://trello.com/c/SuTQEt4S/186-add-well-known-securitytxt)

This adds a  /.well-known/security.txt in line with[ the gds way](https://gds-way.digital.cabinet-office.gov.uk/standards/vulnerability-disclosure.html#vulnerability-disclosure), which helps people report vulnerabilities to cyber.
It does this by redirecting to alphagov's security.txt from `/security.txt.html` and `/.well-known/security.txt.html`

### Things to consider when reviewing

I have tested this locally, and we are redirected to the [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) as expected when visiting the following urls:
- http://localhost:5100/.well-known/security.txt.html
- http://localhost:5100/security.txt.html

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
