### PR TITLE
Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ node_modules
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+.DS_Store


### PR DESCRIPTION
.DS_Store files are macOS-specific metadata files that there is no need to share, so shouldn't be tracked by git