### PR TITLE
Correct formatting error in privacy.erb

### DIFF
--- a/app/views/pages/privacy.erb
+++ b/app/views/pages/privacy.erb
@@ -28,7 +28,9 @@ How we use that data is covered in the standard privacy notice that’s created 
 
 <h2 class="govuk-heading-m">Data we collect from you</h2>
 
+<p>
 This privacy notice explains what personal data the Cabinet Office collects from you, as someone using GOV.UK Forms - for example, to create and publish forms. Cabinet Office is the data controller for this data. <%= govuk_link_to "Read the Cabinet Office’s entry in the Data Protection Public Register", "https://ico.org.uk/ESDWebPages/Entry/Z7414053" %> for more information.
+</p>
 
 <p>The legal basis for processing this data is:</p>
 


### PR DESCRIPTION
### What problem does this pull request solve?

There's a formatting problem with the paragraph starting 'This privacy notice explains what personal data the Cabinet Office collects from you, as someone using GOV.UK Forms ...'

<img width="756" alt="Screenshot 2024-07-23 at 19 38 24" src="https://github.com/user-attachments/assets/b1f893f4-4ea1-4a64-aa9d-d607ed180740">

I think it's because I omitted to wrap the paragraph in <p> </p> tags - this PR adds them.

But I can't run the app locally, so would be great if someone could do a visual check before merging.