### PR TITLE
Fix Sass 'mixed declarations' warning

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -63,9 +63,9 @@ div.feature-panel {
 }
 // scss-lint:enable IdSelector
 .hero-alternative-action {
-  @include govuk-font($size: 19);
   margin-bottom: govuk-spacing(3);
   position: relative;
+  @include govuk-font($size: 19);
 }
 
 .hero-breadcrumb-banner {
@@ -102,9 +102,9 @@ div.feature-panel {
 }
 // scss-lint:enable IdSelector
 .hero-alternative-action {
-  @include govuk-font($size: 19);
   margin-bottom: govuk-spacing(3);
   position: relative;
+  @include govuk-font($size: 19);
 }
 
 .hero-breadcrumb-banner {
@@ -170,12 +170,14 @@ div.feature-panel {
 
 .documentation-design-recommendations {
   .documentation-contents-item {
+    margin-bottom: 5px;
+
     &:before {
       content: "—";
       margin-left: -20px;
       color: #505a5f;
     }
-    margin-bottom: 5px;
+
     a {
       margin-left: 5px;
     }

--- a/app/frontend/styles/_hero-alternative-action.scss
+++ b/app/frontend/styles/_hero-alternative-action.scss
@@ -16,10 +16,10 @@
 // </span>
 
 .hero-alternative-action {
-  @include govuk-font($size: 19);
   margin-bottom: govuk-spacing(3);
   position: relative;
   display: inline-block;
+  @include govuk-font($size: 19);
 
   @include govuk-media-query(tablet) {
     white-space: nowrap;

--- a/app/frontend/styles/_hero.scss
+++ b/app/frontend/styles/_hero.scss
@@ -68,13 +68,13 @@
   }
 
   &__description {
-    @include govuk-font($size: 24);
     color: govuk-colour("white");
+    @include govuk-font($size: 24);
   }
 
   &__paragraph {
-    @include govuk-font($size: 19);
     color: govuk-colour("white");
+    @include govuk-font($size: 19);
   }
 
   &__title,

--- a/app/frontend/styles/_navigation.scss
+++ b/app/frontend/styles/_navigation.scss
@@ -34,8 +34,8 @@
   }
 
   &--list-item {
-    @include govuk-font($size: 16);
     margin-top: govuk-spacing(2);
+    @include govuk-font($size: 16);
 
     @include govuk-media-query(tablet) {
       display: inline-block;

--- a/app/frontend/styles/_related-items.scss
+++ b/app/frontend/styles/_related-items.scss
@@ -16,15 +16,15 @@
   margin: govuk-spacing(4) 0;
 
   &__title {
-    @include govuk-font($size: 24, $weight: bold);
     margin-bottom: govuk-spacing(2);
+    @include govuk-font($size: 24, $weight: bold);
   }
 
   &__list {
-    @include govuk-font($size: 16);
     list-style: none;
     padding-left: 0;
     margin: 0 0 govuk-spacing(3);
+    @include govuk-font($size: 16);
 
     li {
       margin-bottom: govuk-spacing(2);

--- a/app/frontend/styles/_sub-navigation.scss
+++ b/app/frontend/styles/_sub-navigation.scss
@@ -9,11 +9,11 @@
   }
 
   &__item {
-    @include govuk-font($size: 19);
-
     border-bottom: 1px $govuk-border-colour solid;
     display: block;
     padding: govuk-spacing(2) 0;
+
+    @include govuk-font($size: 19);
 
     a:link {
       text-decoration: none;


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/m5hB6sVM/2088-resolve-sass-mixed-declarations-deprecation-warning

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Fixes a [deprecation warning](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) related to the way that the sass declarations are ordered. In v2, the way these  declarations are turned into CSS will change and if they're left as they are they'll generate more CSS than is
necessary.

There shouldn't be any visual differences as a result of these changes. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
