### PR TITLE
Remove redundant thrust script

### DIFF
--- a/bin/thrust
+++ b/bin/thrust
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-require "rubygems"
-require "bundler/setup"
-
-load Gem.bin_path("thruster", "thrust")


### PR DESCRIPTION
This was added as part of the Rails 8 upgrade, but we don't need it as we don't use Thruster and are using NGINX.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
