### PR TITLE
Switch to modern Sass api

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -1,5 +1,4 @@
-$govuk-images-path: "@govuk/assets/images/";
-$govuk-fonts-path: "@govuk/assets/fonts/";
+$govuk-assets-path: "@govuk/assets/";
 $govuk-global-styles: true;
 $govuk-suppressed-warnings: (
   ie8

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -5,7 +5,7 @@ $govuk-suppressed-warnings: (
   ie8
 );
 
-@import "@govuk/all";
+@import "pkg:govuk-frontend";
 
 @import "../styles/responsive-embed";
 @import "../styles/sub-navigation";

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -7,9 +7,6 @@ $govuk-suppressed-warnings: (
 
 @import "pkg:govuk-frontend";
 
-@import "../styles/responsive-embed";
-@import "../styles/sub-navigation";
-
 @import "../styles/borders";
 @import "../styles/breadcrumbs";
 @import "../styles/header";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path'
 import { defineConfig } from 'vite'
 import RubyPlugin from 'vite-plugin-ruby'
+import { NodePackageImporter } from 'sass'
 
 export default defineConfig({
   plugins: [RubyPlugin()],
@@ -9,7 +10,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         api: 'modern',
-        loadPaths: ['./node_modules/govuk-frontend/'],
+        importers: [new NodePackageImporter()],
         quietDeps: true
       },
       devSourcemaps: true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,14 +3,13 @@ import { defineConfig } from 'vite'
 import RubyPlugin from 'vite-plugin-ruby'
 
 export default defineConfig({
-  plugins: [
-    RubyPlugin(),
-  ],
+  plugins: [RubyPlugin()],
   build: { emptyOutDir: true },
   css: {
     preprocessorOptions: {
       scss: {
-        includePaths: ['./node_modules/govuk-frontend/'],
+        api: 'modern',
+        loadPaths: ['./node_modules/govuk-frontend/'],
         quietDeps: true
       },
       devSourcemaps: true
@@ -18,7 +17,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@govuk': path.resolve(__dirname, 'node_modules/govuk-frontend/dist/govuk'),
+      '@govuk': path.resolve(
+        __dirname,
+        'node_modules/govuk-frontend/dist/govuk'
+      ),
       '@images': path.resolve(__dirname, 'app/frontend/images')
     }
   }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/pfzCTVnB/2066-investigate-asset-building-issue-with-modern-sass-api

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We were seeing [an issue with assets failing to build properly using the 'modern' Sass API](https://trello.com/c/pfzCTVnB/2066-investigate-asset-building-issue-with-modern-sass-api). After investigating this appears to be caused by a bug in the Vite internal sass importer (https://github.com/vitejs/vite/issues/19196). 

This PR:
- uses the sass NodePackageImporter import govuk-frontend, which bypasses that bug and also offers us some other advantages (see commit message for more details)
- updates to use the modern API
- removes some redundant imports
- uses a more compact API for setting the asset paths

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
