### PR TITLE
Add Performance metrics page

### DIFF
--- a/app/components/metrics_summary_component/_index.scss
+++ b/app/components/metrics_summary_component/_index.scss
@@ -1,0 +1,35 @@
+@use "pkg:govuk-frontend" as govuk;
+
+.app-metrics__container {
+  margin-bottom: govuk.govuk-spacing(6);
+
+  @include govuk.govuk-media-query(tablet) {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(govuk.govuk-px-to-rem(260), 6fr));
+    gap: govuk.$govuk-gutter;
+  }
+}
+
+.app-metrics__big-number {
+  padding: govuk.govuk-spacing(1) govuk.govuk-spacing(0);
+  margin-bottom: govuk.govuk-spacing(2);
+
+  @include govuk.govuk-font-size(19);
+  @include govuk.govuk-typography-common;
+
+  @include govuk.govuk-media-query(tablet) {
+    @supports (display: grid) {
+      display: flex;
+      flex-flow: column nowrap;
+      justify-content: space-between;
+    }
+  }
+}
+
+.app-metrics__big-number-number {
+  display: block;
+  margin-top: govuk.govuk-spacing(1);
+
+  @include govuk.govuk-font-size(48);
+  @include govuk.govuk-typography-weight-bold;
+}

--- a/app/components/metrics_summary_component/_index.scss
+++ b/app/components/metrics_summary_component/_index.scss
@@ -5,7 +5,7 @@
 
   @include govuk.govuk-media-query(tablet) {
     display: grid;
-    grid-template-columns: repeat(3, minmax(govuk.govuk-px-to-rem(260), 6fr));
+    grid-template-columns: repeat(3, minmax(govuk.govuk-px-to-rem(100), 1fr));
     gap: govuk.$govuk-gutter;
   }
 }

--- a/app/components/metrics_summary_component/view.html.erb
+++ b/app/components/metrics_summary_component/view.html.erb
@@ -1,0 +1,16 @@
+<div class="app-metrics">
+  <% if error_message.present? %>
+    <div class="govuk-inset-text">
+      <%= error_message.html_safe %>
+    </div>
+  <% else %>
+    <div class="app-metrics__container">
+      <% metrics.each do |key, value| %>
+      <div class="app-metrics__big-number">
+        <span class="app-metrics__big-number-number"><%= number_with_delimiter(value) %></span>
+        <%= t("performance_data.#{key}") %>
+      </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/metrics_summary_component/view.rb
+++ b/app/components/metrics_summary_component/view.rb
@@ -1,0 +1,14 @@
+module MetricsSummaryComponent
+  class View < ViewComponent::Base
+    attr_reader :error_message, :metrics
+
+    def initialize(metrics)
+      super
+      @metrics = metrics
+
+      if metrics.blank?
+        @error_message = I18n.t("metrics_summary.errors.no_data")
+      end
+    end
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 class PagesController < ApplicationController
   def index
+    @performance_data = YAML.load_file(Rails.root.join("config/performance_metrics.yml"))["performance_metrics"]
+    @last_updated = File.mtime(Rails.root.join("config/performance_metrics.yml").to_s).to_date.to_formatted_s(:rfc822)
     render(layout: "layouts/homepage")
   end
 

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -1,0 +1,11 @@
+class PerformanceController < ApplicationController
+  def index
+    @performance_data = YAML.load_file(Rails.root.join("config/performance_metrics.yml"))["performance_metrics"]
+    @last_updated = File.mtime(Rails.root.join("config/performance_metrics.yml").to_s).to_date.to_formatted_s(:rfc822)
+
+    respond_to do |format|
+      format.html { render :index }
+      format.json { render json: @performance_data, status: :ok }
+    end
+  end
+end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -11,6 +11,7 @@
 @use "../styles/image";
 @use "../styles/inverted-button";
 @use "../styles/masthead";
+@use "../../components/metrics_summary_component";
 @use "../styles/navigation";
 @use "../styles/related-items";
 @use "../styles/responsive-embed";

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -114,6 +114,8 @@
     class="govuk-section-break govuk-section-break--l govuk-section-break--visible"
   />
 
+  <%= render "partials/performance_metrics" %>
+
   <div class="govuk-grid-row govuk-!-margin-bottom-7">
     <div class="govuk-grid-column-one-half feature-column">
       <section class="content-section">
@@ -144,6 +146,9 @@
               href="https://gds.blog.gov.uk/2021/07/06/making-all-forms-on-gov-uk-accessible-easy-to-use-and-quick-to-process/"
               >the vision to make all forms on GOV.UK accessible, easy to use and quick to process</a
             >
+          </li>
+          <li>
+            <a class="govuk-link" href="/performance">how GOV.UK Forms is used</a>
           </li>
         </ul>
       </section>

--- a/app/views/pages/terms_of_use.html.erb
+++ b/app/views/pages/terms_of_use.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(t("page_titles.terms_of_use")) %>
+<% set_page_title(t("terms_of_use.page_title")) %>
 
 <h1 class="govuk-heading-l">
   <%=t("page_titles.terms_of_use")%>

--- a/app/views/partials/_performance_metrics.html.erb
+++ b/app/views/partials/_performance_metrics.html.erb
@@ -1,11 +1,7 @@
-<h2 class="govuk-heading-m"><%= t("performance_data.subtitle") %></h2>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half govuk-grid-column-one-half-from-desktop">
-    <%= render MetricsSummaryComponent::View.new(@performance_data) %>
-  </div>
-</div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m"><%= t("performance_data.subtitle") %></h2>
+    <%= render MetricsSummaryComponent::View.new(@performance_data) %>
     <p>last updated: <%= @last_updated %></p>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   </div>

--- a/app/views/partials/_performance_metrics.html.erb
+++ b/app/views/partials/_performance_metrics.html.erb
@@ -1,0 +1,12 @@
+<h2 class="govuk-heading-m"><%= t("performance_data.subtitle") %></h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half govuk-grid-column-one-half-from-desktop">
+    <%= render MetricsSummaryComponent::View.new(@performance_data) %>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p>last updated: <%= @last_updated %></p>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  </div>
+</div>

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -1,0 +1,4 @@
+<% set_page_title(t("performance_data.page_title")) %>
+
+<h1 class="govuk-heading-xl"><%= t("performance_data.page_title") %></h1>
+<%= render "partials/performance_metrics" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,12 @@ en:
   metrics_summary:
     errors:
       no_data: 'No data available'
+  performance_data:
+    page_title: 'Performance'
+    subtitle: 'How GOV.UK Forms is being used'
+    submissions: 'form submissions since September 2022'
+    organisations: 'organisations using GOV.UK Forms'
+    published: 'published forms'
   terms_of_use:
     accessibility:
       heading: Make forms that are easy to use and accessible

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,8 +3,6 @@ en:
   continue: Continue
   header:
     product_name: Forms
-  page_titles:
-    terms_of_use: Terms of use
   terms_of_use:
     accessibility:
       heading: Make forms that are easy to use and accessible
@@ -24,6 +22,7 @@ en:
       section_1: You must make sure your use of GOV.UK Forms to collect personal data complies with data protection legislation and your organisation’s policies for collecting, processing and storing data.
       section_2: Your organisation is the ‘data controller’ for any data you collect using GOV.UK Forms.
       section_3: To get help with data protection legislation compliance, speak with your organisation’s data protection officer or data protection team.
+    page_title: Terms of use
     security:
       accessing_the_platform:
         heading: Accessing the platform

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,9 @@ en:
   continue: Continue
   header:
     product_name: Forms
+  metrics_summary:
+    errors:
+      no_data: 'No data available'
   terms_of_use:
     accessibility:
       heading: Make forms that are easy to use and accessible

--- a/config/performance_metrics.yml
+++ b/config/performance_metrics.yml
@@ -1,0 +1,5 @@
+performance_metrics:
+  organisations: 57
+  published: 118
+  submissions: 209306
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
 
   get "/mailing-list" => redirect("https://service.us12.list-manage.com/subscribe?u=cb74eb9a6898b0e5870fede0a&id=451fe4c1e1")
 
+  resources :performance, only: %i[index]
+
   get "/security.txt" => redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
   get "/.well-known/security.txt" => redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
 

--- a/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
+++ b/spec/components/metrics_summary_component/metrics_summary_component_preview.rb
@@ -1,0 +1,5 @@
+class MetricsSummaryComponent::MetricsSummaryComponentPreview < ViewComponent::Preview
+  def default
+    render(MetricsSummaryComponent::View.new([{ label: "Processor Time Saved", number: 100 }]))
+  end
+end

--- a/spec/components/metrics_summary_component/view_spec.rb
+++ b/spec/components/metrics_summary_component/view_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe MetricsSummaryComponent::View, type: :component do
+  context "when there is data to render" do
+    let(:metrics) do
+      described_class.new(
+        {
+          organisations: 100,
+          submissions: 209_306,
+          published: 118,
+        },
+      )
+    end
+
+    before do
+      render_inline(metrics)
+    end
+
+    it "renders the component" do
+      expect(page).to have_text("published")
+      expect(page).to have_text("118")
+    end
+  end
+
+  context "when there is no data to render" do
+    let(:metrics) { described_class.new([]) }
+
+    it "renders an error" do
+      render_inline(metrics)
+
+      expect(page).to have_text("No data available")
+    end
+  end
+end

--- a/spec/requests/performance_spec.rb
+++ b/spec/requests/performance_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Performances", type: :request do
+  describe "GET /index" do
+    before do
+      get performance_index_path
+    end
+
+    it "returns ok" do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /index.json" do
+    it "returns JSON" do
+      get performance_index_path(format: :json)
+
+      expect(response.content_type).to eq("application/json; charset=utf-8")
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/4HM3T6Na/2118-create-initial-performance-page-in-product-pages

Adds a new page/partial for the performance data we want to highlight.

## Screenshots

![localhost_3002_performance (2)](https://github.com/user-attachments/assets/b4794ab9-bbf7-40eb-9608-76763c1f1419)
![localhost_3002_ (1)](https://github.com/user-attachments/assets/5bb06d33-073a-417f-b1d8-b2cfb8b57f4c)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
