### PR TITLE
Add workaround for capybara failure

### DIFF
--- a/spec/features/support_form_spec.rb
+++ b/spec/features/support_form_spec.rb
@@ -44,7 +44,7 @@ describe "Support form", type: :system do
     choose "I’m a member of the public with a question about a government form or service", visible: :all
     click_button "Continue"
 
-    expect(page.current_url).to eq "https://www.gov.uk/contact"
     expect(page).to have_text "Find contact details for services"
+    expect(page.current_url).to eq "https://www.gov.uk/contact"
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We're seeing an issue where it appears that Capybara isn't waiting for the page navigation to complete before checking the URL, resulting in a wrongly failing test.

For some matchers, such as have_text, Capybara waits for the text to become available. That wait logic still appears to be working correctly.

This commit switches the order of our have_text and current_url assertions, so that the current_url assertion benefits from have_text matcher's wait logic.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
