### PR TITLE
 Use chromedriver v128 in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,16 @@ jobs:
     env:
       RAILS_ENV: "test"
     steps:
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: '128.0.6613.8600'
+          chromeapp: chrome
+      - run: |
+          sudo apt-get purge google-chrome-stable
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: 'false'
       - name: Checkout code
         uses: actions/checkout@v4
       # Add or replace dependency steps here

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.29.1)
+    selenium-webdriver (4.30.1)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require_relative "../config/environment"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
+require_relative "support/capybara_headless_chrome"
 require_relative "support/capybara_selenium_webdriver"
 
 require "sentry/test_helper"

--- a/spec/support/capybara_headless_chrome.rb
+++ b/spec/support/capybara_headless_chrome.rb
@@ -1,0 +1,43 @@
+require "selenium/webdriver"
+
+options = Selenium::WebDriver::Chrome::Options.new
+options.add_preference(:download, prompt_for_download: false,
+                                  default_directory: "/tmp/downloads")
+
+options.add_preference(:browser, set_download_behavior: { behavior: "allow" })
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  options.add_argument("--headless")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--window-size=1280,1024")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+
+  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+
+  ### Allow file downloads in Google Chrome when headless!!!
+  ### https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89
+  bridge = driver.browser.send(:bridge)
+
+  path = "/session/:session_id/chromium/send_command"
+  path[":session_id"] = bridge.session_id
+
+  bridge.http.call(:post, path, cmd: "Page.setDownloadBehavior",
+                                params: {
+                                  behavior: "allow",
+                                  downloadPath: "/tmp/downloads",
+                                })
+  ###
+
+  driver
+end
+
+Capybara.default_driver = Settings.show_browser_during_tests ? :chrome : :headless_chrome
+
+Capybara.configure do |config|
+  config.automatic_label_click = true
+end


### PR DESCRIPTION
We are seeing intermittent failures when feature tests run in github actions. These failures are related to selenium and chromedriver. They are false positives and do not mean the code is broken.

This commit copies the solution gov.uk applied to their codebase.

https://github.com/alphagov/publisher/pull/2596/commits/68adc8858782949a1a38f4eb582a17462eb0e51c

This change should only be needed until the chromedriver/chrome version issue is fixed.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
