### PR TITLE
Fix alignment for sign in link on small screens

### DIFF
--- a/app/components/service_navigation_component/_index.scss
+++ b/app/components/service_navigation_component/_index.scss
@@ -1,8 +1,12 @@
+@use "pkg:govuk-frontend" as govuk;
+
 .app-service-navigation .govuk-service-navigation__wrapper {
   width: 100%;
 }
 
 .app-service-navigation__item--featured {
-  flex: 1 0 auto;
-  text-align: right;
+  @include govuk.govuk-media-query($from: tablet) {
+    flex: 1 0 auto;
+    text-align: right;
+  }
 }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/xGYhUwWH/2206-update-the-navigation-on-the-govuk-forms-product-page

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Styling tweak to #722 so that the right-alignment only applies at tablet width or wider.

### Screenshots
#### Before
![Screenshot of the menu on a narrow screen, with 'Get started', 'Features', and 'Support' links aligned to the left, and  'Sign in' aligned to the right](https://github.com/user-attachments/assets/6114d604-ebae-4f53-9c71-401e5ecf82e6)

#### After
![Screenshot of the menu on a narrow screen, with 'Get started', 'Features', 'Support', and 'Sign in' links aligned to the left](https://github.com/user-attachments/assets/51813f4a-e2f4-4928-b9ab-4884b7855766)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
