### PR TITLE
[DO NOT MERGE YET] Add branching to features and forthcoming features pages

### DIFF
--- a/app/views/pages/features.html.erb
+++ b/app/views/pages/features.html.erb
@@ -74,12 +74,15 @@
 </p>
 
 <h3 class="govuk-heading-m">
-  Skip questions based on a response
+  Add a route to skip questions based on a specific answer
 </h3>
 
 <p>
-  With a question route, you can skip someone to a later question in your form based on
-  their response to a question where they have to select one answer from a list.
+  You can add a route to a question where people select only one option from a list. You’ll specify which option the route starts from and, if someone selects that option, they’ll be skipped forward to a later question, or the end of the form. 
+</p>
+
+<p>
+  People who select any other answer will continue to the next question and through the rest of the form. 
 </p>
 
 <p>
@@ -87,6 +90,21 @@
   questions about that thing if they select ‘Yes’. Anyone who answers ‘No’ will be skipped
   forward to the next question that’s relevant for them.
 </p>
+
+<h3 class="govuk-heading-m">
+ Add a second route to create 2 ‘branches’ of questions
+</h3>
+
+<p>
+  If you need to, you can add a second route to make people who select any other answer skip the questions you sent the first route to. This will give you 2 sets of questions - or ‘branches’ - based on one answer. 
+</p>
+
+<p>So, for example, you can:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>ask one set of questions for people who answer ‘Yes’ and another set for people who answer ‘No’</li>
+  <li>ask one set of questions if the answer is ‘A’ and another set if the answer is ‘B’, ‘C’ or ‘D’</li>
+</ul>
 
 <h3 class="govuk-heading-m">
   Forms use GOV.UK Design System styles, components and patterns

--- a/app/views/pages/forthcoming_features.html.erb
+++ b/app/views/pages/forthcoming_features.html.erb
@@ -17,25 +17,25 @@
 <h2 class="govuk-heading-l">What we’re working on now</h2>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>‘Branching’ to give people a different set of questions depending on their answer to a previous question</li>
   <li>‘Exit pages’ to tell someone they cannot use the form after they’ve answered some qualifying questions</li>
+  <li>Form components in Welsh so you can make a Welsh language form</li>
 </ul>
 
-<h2 class="govuk-heading-l">What we plan to work on in 2025</h2>
+<h2 class="govuk-heading-l">Later in 2025</h2>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Allowing people to save their progress through a form and return later on</li>
   <li>Improving how you manage users and forms in an organisation</li>
   <li>Allowing people to answer a group of questions multiple times</li>
-  <li>Form components in Welsh so you can make a Welsh language form</li>
   <li>Previews of what each question will look like as you’re adding them to your form</li>
-  <li>Customisable branding so you can change the way forms look</li>
-  <li>The ability to receive form submissions in different ways - for example from cloud storage</li>
 </ul>
 
 <h2 class="govuk-heading-l">Further in the future</h2>
 
 <ul class="govuk-list govuk-list--bullet">
+  <li>Customisable branding so you can change the way forms look</li>
+  <li>‘Branching’ improvements to allow you to have more than 2 branches from a question</li>
+  <li>The ability to receive form submissions in different ways - for example from cloud storage</li>
   <li>Opening up use of GOV.UK Forms to the wider public sector</li>
   <li>A history of previous versions of a form, and the ability to revert back to them</li>
   <li>Question templates so you can add common questions to a form even faster</li>


### PR DESCRIPTION
[DRAFT ONLY - NOT READY TO MERGE YET]

April 2025 updates to 'Forthcoming features' page:

- Removed branching from 'What we're working on now' as we’re releasing it
- Moved Welsh form components up to ‘What we're working on now’
- Changed 'What we plan to work on in 2025' heading to ‘Later in 2025’
- Added multiple branches, customisable branding and receiving submissions in different ways to ‘Further in the future’

Updates to features page ('How GOV.UK Forms works'):

- Edited the existing ‘Set questions to skip’ section. Gave it a new heading: ‘Add a route to skip questions based on a specific answer’.
- Added a new section explaining 2-route branching, under the heading ‘Add a second route to create 2 ‘branches’ of questions’

### What problem does this pull request solve?

Trello card: https://trello.com/c/makV4kgB/2213-prepare-comms-for-releasing-branching

Forthcoming features page edits are shown as track changes in this Google doc: https://docs.google.com/document/d/1IqpP6VgFOFewqtcTeATa5ItPfD4dRUq7vFnbZUzXhts/edit?pli=1&tab=t.2p1pn726fps5

Features page edits are shown as track changes in this doc: https://docs.google.com/document/d/10TEpn9dbAnEGm97KxINgQCYD0rzijmwLT48K7V49YkA/edit?pli=1&tab=t.3sls1utzi4e4

### Things to consider when reviewing

- Is the code correct? (Please double check as I haven't used GitHub for a while!)
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
