### PR TITLE
Add feature flag for rebrand

### DIFF
--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -1,0 +1,10 @@
+class FeatureService
+  class << self
+    def enabled?(feature_name)
+      return false if Settings.features.blank?
+
+      segments = feature_name.to_s.split(".")
+      Settings.features.dig(*segments)
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+features:
+  rebrand: false
+
 forms_admin:
   # URL to form-admin
   base_url: http://localhost:3000

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+features:
+  rebrand: true

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe FeatureService do
+  describe ".enabled?" do
+    context "when feature is enabled" do
+      before do
+        Settings.features[:some_feature] = true
+      end
+
+      it "returns true" do
+        response = described_class.enabled?(:some_feature)
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "when feature is disabled" do
+      before do
+        Settings.features[:some_feature] = false
+      end
+
+      it "returns false" do
+        response = described_class.enabled?(:some_feature)
+
+        expect(response).to be_falsey
+      end
+    end
+
+    context "when empty features" do
+      before do
+        allow(Settings).to receive(:features).and_return(nil)
+      end
+
+      it "returns false" do
+        response = described_class.enabled?(:some_feature)
+
+        expect(response).to be_falsey
+      end
+    end
+
+    context "when nested features" do
+      before do
+        Settings.features[:some] = OpenStruct.new(nested_feature: true)
+      end
+
+      it "returns true" do
+        response = described_class.enabled?("some.nested_feature")
+
+        expect(response).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

To manage the rollout of the GOV.UK Rebrand, we're adding a feature flag to this app to help.

We also add a FeatureService which is lifted from Runner. If we don't need feature flags for Product in future we can delete it entirely.

See also: https://github.com/alphagov/forms-runner/pull/1397 

Trello card: https://trello.com/c/ROAXJEiF/2860-add-feature-flags-to-product-pages-and-runner-for-rebranding 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
