### PR TITLE
Schedule dependabot updates every Sunday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,16 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10
 
   # Maintain dependencies for Ruby/Rails bundler
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "direct"
@@ -26,5 +28,6 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10


### PR DESCRIPTION
### What problem does this pull request solve?

Dependabot updates are getting burdensome. Dependabot docs recommend [scheduling updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#controlling-the-frequency-and-timings-of-dependency-updates) to reduce this workload somewhat. The goal here is that the week's dependabot PRs would all be raised at the beginning of the working week, giving us time to sort them out before more get raised the following week. Security updates should still get raised along with associated security alerts.

In future we could also use groups to e.g. gather all dev dependencies into a single PR.
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
