### PR TITLE
Correct wording in unpause task

### DIFF
--- a/lib/tasks/pause_pipelines.rake
+++ b/lib/tasks/pause_pipelines.rake
@@ -38,7 +38,7 @@ namespace :pipeline do
       task unpause: :environment do
         pipeline_name = pipeline_name env_name
 
-        puts "Pausing pipeline #{pipeline_name}"
+        puts "Unpausing pipeline #{pipeline_name}"
 
         codepipeline = Aws::CodePipeline::Client.new
         pipeline_definition = codepipeline.get_pipeline(name: pipeline_name)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Changes the unpause task to say 'Unpausing' instead of 'Pausing'.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
