### PR TITLE
Create volumes for whole directories in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,11 +47,6 @@ RUN npm ci --ignore-scripts --only=production
 
 FROM base AS app
 
-# Each directory that Rails or our application needs to
-# write to under /app/tmp/ must be added individually
-VOLUME "/tmp/"
-VOLUME "/app/tmp/sockets/"
-
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin" \
     USER="ruby" \
@@ -73,6 +68,10 @@ RUN chmod 0755 bin/*
 
 COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
 COPY --chown=ruby:ruby --from=build /app /app
+
+RUN mkdir -p "/app/tmp/" && chown ruby:ruby "/app/tmp/"
+VOLUME "/tmp/"
+VOLUME "/app/tmp/"
 
 EXPOSE 3000
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

Previously we created 1 volume for each directory that the application needed to write to, because we found it didn't have permission to create subdirectories of a volume.

This is because we weren't doing it correctly. The correct way to do it is to create the directory in the Dockerfile and set its permissions and owner, then expose it as a volume.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
