### PR TITLE
Features and forthcoming features page updates (June) - product site

### DIFF
--- a/app/views/pages/features.html.markerb
+++ b/app/views/pages/features.html.markerb
@@ -18,7 +18,7 @@ These are the steps to make a form with GOV.UK Forms.
 
 ## Features available now
 
-During this early phase of development, we're focusing on the simplest and most commonly needed form features first.
+During this early phase of development, we're focusing on the most commonly needed form features first.
 
 ### Create questions
 
@@ -50,7 +50,7 @@ For questions that ask for certain types of personal information (such as a name
 
 ### Add a route to skip questions based on a specific answer
 
-You can add a route to a question where people select only one option from a list. You'll specify which option the route starts from and, if someone selects that option, they'll be skipped forward to a later question, or the end of the form.
+You can add a route to a question where people select only one option from a list. You'll specify which option the route starts from and, if someone selects that option, they'll be skipped forward to a later question, the end of the form, or an exit page to remove them from the form.
 
 People who select any other answer will continue to the next question and through the rest of the form.
 
@@ -64,6 +64,10 @@ So, for example, you can:
 
 - ask one set of questions for people who answer 'Yes' and another set for people who answer 'No'
 - ask one set of questions if the answer is 'A' and another set if the answer is 'B', 'C' or 'D'
+
+### Add an ‘exit page’ to remove someone from a form 
+
+You can route someone to an ‘exit page’ based on their response to a question. You can use the exit page to tell them why they cannot use the form and explain what they should do instead.
 
 ### Forms use GOV.UK Design System styles, components and patterns
 

--- a/app/views/pages/forthcoming_features.html.markerb
+++ b/app/views/pages/forthcoming_features.html.markerb
@@ -11,7 +11,6 @@ We'll update everyone with an account when we release new features. Or you can <
 
 ## What we're working on now
 
-- 'Exit pages' to tell someone they cannot use the form after they've answered some qualifying questions
 - Form components in Welsh so you can make a Welsh language form
 
 ## Later in 2025


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: [Prepare comms for releasing exit pages](https://trello.com/c/lYK3tSvx/2263-prepare-comms-for-releasing-exit-pages?filter=label:Feature%20team%20two)

Updates to both the features page ['How GOV.UK Forms works'](https://www.forms.service.gov.uk/features) and ['Forthcoming features' page](https://www.forms.service.gov.uk/forthcoming-features)

#### Features page
- Added a new exit pages section
- Added mention of exit pages to the 'Add a route to skip questions based on a specific answer' section
- Removed the word 'simplest' from intro line of the 'Features available now' section

See ['Features page updates']( https://docs.google.com/document/d/10TEpn9dbAnEGm97KxINgQCYD0rzijmwLT48K7V49YkA/edit?pli=1&tab=t.30ekdtqhocfp)doc for tracked changes 

#### Forthcoming features page
- Removed mention of exit pages under 'What we're working on now'

See ['Forthcoming features page updates'](https://docs.google.com/document/d/1IqpP6VgFOFewqtcTeATa5ItPfD4dRUq7vFnbZUzXhts/edit?pli=1&tab=t.79r5gwgs3mik) for tracked changes

### Things to consider when reviewing

- Is the markdown all ok? (Yay for markdown!)
- Does it match the updates on the Word docs? 
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
