### PR TITLE
Remove beta tag

### DIFF
--- a/app/components/header_component/view.rb
+++ b/app/components/header_component/view.rb
@@ -9,7 +9,7 @@ module HeaderComponent
 
     def call
       govuk_header(homepage_url:, classes: "govuk-header--full-width-border") do |header|
-        header.with_product_name(**product_name_with_tag)
+        header.with_product_name(name: "Forms")
       end
     end
 
@@ -17,16 +17,6 @@ module HeaderComponent
 
     def homepage_url
       root_path
-    end
-
-    def product_name_with_tag
-      {
-        name: "#{I18n.t('header.product_name')} #{product_tag}".html_safe,
-      }
-    end
-
-    def product_tag
-      govuk_tag(text: phase_name, classes: %w[govuk-phase-banner__content__tag]).html_safe
     end
   end
 end

--- a/app/views/pages/features.html.markerb
+++ b/app/views/pages/features.html.markerb
@@ -18,7 +18,7 @@ These are the steps to make a form with GOV.UK Forms.
 
 ## Features available now
 
-GOV.UK Forms is in public beta. This means it's fully operational and supported, but we're regularly adding new features, focusing on the most commonly needed features first.
+GOV.UK Forms is in public beta. This means it’s fully operational and supported, but we’re regularly adding new features, focusing on the most commonly needed features first.
 
 ### Create questions
 

--- a/app/views/pages/features.html.markerb
+++ b/app/views/pages/features.html.markerb
@@ -18,7 +18,7 @@ These are the steps to make a form with GOV.UK Forms.
 
 ## Features available now
 
-During this early phase of development, we're focusing on the most commonly needed form features first.
+GOV.UK Forms is in public beta. This means it's fully operational and supported, but we're regularly adding new features, focusing on the most commonly needed features first.
 
 ### Create questions
 

--- a/spec/components/header_component/view_spec.rb
+++ b/spec/components/header_component/view_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe HeaderComponent::View, type: :component do
       expect(page).to have_link("GOV.UK Forms", href: "/")
     end
 
-    it "includes the phase tag" do
-      expect(page).to have_css(".govuk-tag", text: phase_name)
-    end
-
     it "has a full width border" do
       expect(page).to have_css(".govuk-header--full-width-border")
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/qBeUKH2I/2320-remove-beta-from-header-as-part-of-rebrand-on-product-pages

After the rebrand, the phase tag causes the product name to reflow to the next line on mobile displays with a small viewport (320px). Notify did some research on this and found that it didn't mean much to users so decided to follow suit.

As we've removed the beta tag, add some additional content about being in public beta.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
