### PR TITLE
Change accessibility statement footer link text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   continue: Continue
   footer:
     meta_items:
-      accessibility: Accessibility
+      accessibility: Accessibility statement
       cookies: Cookies
       privacy: Privacy
       terms_of_use: Terms of use


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Changes the link text from 'Accessibility' to 'Accessibility statement', in order to make the target of the link more explicit and be consistent with the admin and runner footers.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
