### PR TITLE
Move vite assets to /assets

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -5,7 +5,9 @@
     "additionalEntrypoints": [
       "~/{assets,fonts,icons,images}/**/*",
       "node_modules/govuk-frontend/dist/govuk/assets/**/*"
-    ]
+    ],
+    "publicOutputDir": "assets",
+    "assetsDir": ""
   },
   "development": {
     "autoBuild": true,


### PR DESCRIPTION
Currently the vite build outputs to public/vite/assets. This doesn't match the runner and admin configuration which outputs them to public/assets.

This doesn't matter on it's own but it's a bit confusing to have them in different places.

If we wanted to apply caching at the CDN level, it's easier if they are in a standard location.

This commit aligns the configuration with the runner and admin by putting them in /public/assets.

There shouldn't be any changes to build or how the site works.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
