### PR TITLE
Update the status page URL to custom domain

### DIFF
--- a/app/views/support/support.html.erb
+++ b/app/views/support/support.html.erb
@@ -21,7 +21,7 @@
 <h2 class="govuk-heading-m">Check our system status</h2>
 
 <p>
-  If you have a problem with the platform, check for known issues on the <a href="https://govukforms.statuspage.io/">GOV.UK Forms system status page</a>. You can subscribe to get notifications about current and future issues. 
+  If you have a problem with the platform, check for known issues on the <a href="https://status.forms.service.gov.uk">GOV.UK Forms system status page</a>. You can subscribe to get notifications about current and future issues. 
 </p>
 
 <h2 class="govuk-heading-m">Support during working hours</h2>


### PR DESCRIPTION
This updates the status page URL to use our custom URL (https://status.forms.service.gov.uk).
