### PR TITLE
Strip all HTML comments from input before rendering Markdown

### DIFF
--- a/app/markdown/erb_markdown.rb
+++ b/app/markdown/erb_markdown.rb
@@ -1,6 +1,7 @@
 class ErbMarkdown < ApplicationMarkdown
   def preprocess(html)
     processed_html = render inline: html, handler: :erb
-    processed_html.sub(/^<!-- BEGIN inline template -->/, "").sub(/<!-- END inline template -->$/, "").strip
+    # strip out comments as the markdown renderer converts -- to – causing them to be rendered as text on the page
+    processed_html.gsub(/<!--(.*?)-->/, "").strip
   end
 end


### PR DESCRIPTION
When running locally, where ViewComponents are used, HTML comments were being added with the path of the component file. The Markdown generator was converting the `--` in the comments into em dashes, causing the comments to be rendered as text.

Strip out all HTML comments before rendering the Markdown to avoid this issue.