### PR TITLE
Stop Dependabot version updates for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,3 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-name: "vite_ruby"
-
-  # Maintain dependencies for npm
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Due to recent supply chain attacks on npm [[1]], we have decided to stop Dependabot version updates for our Node.js dependencies, at least for now.

[1]: https://www.aikido.dev/blog/s1ngularity-nx-attackers-strike-again


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?