### PR TITLE
Revert "Stop Dependabot version updates for npm packages"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,11 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-name: "vite_ruby"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### What problem does this pull request solve?
We previously (alphagov/forms-product-page#887) removed npm from our Dependabot configuration in response to the Shai-Hulud npm worm.

This PR readds it since we think the immediate risk has been adequately mitigated.

Reverts alphagov/forms-product-page#887
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
