### PR TITLE
Bump to sentry ruby v6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.15.2)
+    json (2.16.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -341,10 +341,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (5.28.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.28.0)
-    sentry-ruby (5.28.0)
+    sentry-rails (6.1.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.1.0)
+    sentry-ruby (6.1.1)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     simplecov (0.22.0)
@@ -477,7 +477,7 @@ CHECKSUMS
   io-console (0.8.1) sha256=1e15440a6b2f67b6ea496df7c474ed62c860ad11237f29b3bd187f054b925fcb
   irb (1.15.3) sha256=4349edff1efa7ff7bfd34cb9df74a133a588ba88c2718098b3b4468b81184aaa
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.15.2) sha256=1068e1d966d2d0dcaf953eaed09c2d30e4104c64c1e3140c435d17be08d1fa27
+  json (2.16.0) sha256=ca5630320bb5ca23ebfd0bac84532fab56eb357575653b815b9df42c051e1525
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -547,8 +547,8 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.38.0) sha256=0a84e71fef66394ae8d9290d3a5bc24b33de49d45a7aa57fc09f246218bf102f
-  sentry-rails (5.28.0) sha256=a0cbba7ce86312172db9d1b3c39c5302de07e446e7df3f68e4f4b1d240a91fc2
-  sentry-ruby (5.28.0) sha256=745c1db3b85c765993dfeb941830aeafff82d85330cd953410c7f37197b0bd99
+  sentry-rails (6.1.0) sha256=55422991fef630ff5b4bee035f7b0fea6b67d8df0178da668f97ed28e6c8f8f2
+  sentry-ruby (6.1.1) sha256=895e932aef528d0fbc74b823e74224c22fc19e57d0316d24aeda0e7691f9ea8a
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.1) sha256=5dab0b7ee612e60e9887ad57693832fdf4695b4c0c859eaea5f95c18791ef10b
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,7 +7,6 @@ if Settings.sentry.dsn.present?
     config.dsn = Settings.sentry.dsn
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.debug = true
-    config.enable_tracing = false
     config.environment = Settings.sentry.environment
 
     filter = ActiveSupport::ParameterFilter.new(
@@ -15,7 +14,25 @@ if Settings.sentry.dsn.present?
       mask: Settings.sentry.filter_mask,
     )
     config.before_send = lambda do |event, _hint|
-      filter.filter(event.to_hash)
+      if event.extra
+        event.extra = filter.filter(event.extra)
+      end
+      if event.user
+        event.user = filter.filter(event.user)
+      end
+      if event.contexts
+        event.contexts = filter.filter(event.contexts)
+      end
+
+      event
+    end
+
+    config.before_breadcrumb = lambda do |breadcrumb, _hint|
+      if breadcrumb.data
+        breadcrumb.data = filter.filter(breadcrumb.data)
+      end
+
+      breadcrumb
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

config.enable_tracing has been removed in favour of
config.traces_sample_rate, which has a default value of nil

Sentry::Event#to_hash has been replaced by to_h

Returning a hash from before_send is no longer supported and will drop the event. Instead, we need to individually apply the filters to the places where PII could get in as per https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/#using-before-send

We also need to filter the breadcrumbs using config.before_breadcrumb.

This PR doesn't currently attempt to apply the data scrubbing filter to exception messages, we need to find a way to do this as some exception messages can pull in PII, such as a NoMethodError https://trello.com/c/PuVK5TWl/1346-sentry-alert-forms-runner-undefined-method-strip-for-array

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
