### PR TITLE
Add workaround for flaky tests

### DIFF
--- a/spec/support/selenium_error_patch.rb
+++ b/spec/support/selenium_error_patch.rb
@@ -1,0 +1,34 @@
+# Monkey patch for a specific intermittent Selenium error.
+#
+# Intermittently, Selenium/Chromedriver raises `Selenium::WebDriver::Error::UnknownError`
+# with the message "Node with given id does not belong to the document".
+
+# Capybara's automatic waiting/retrying mechanism doesn't catch it,
+# leading to failure.
+#
+# We intercept the initialization of `UnknownError`. If the message matches this specific
+# case, we raise a `StaleElementReferenceError` instead. This uses Capybara's
+# retry logic which makes doesn't fail the test
+#
+# This can be removed once the following issue is resolved:
+# https://github.com/teamcapybara/capybara/issues/2800
+#
+# taken from the following issue:
+# https://github.com/teamcapybara/capybara/issues/2800#issuecomment-3049956982
+
+module Selenium
+  module WebDriver
+    module Error
+      class UnknownError
+        alias_method :old_initialize, :initialize
+        def initialize(msg = nil)
+          if msg&.include?("Node with given id does not belong to the document")
+            raise StaleElementReferenceError, msg
+          end
+
+          old_initialize(msg)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/FiwQ93Ee/2915-timebox-2-days-fix-flaky-rspec-tests <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Adds the workaround from govuk-forms/forms-admin#2076 to this repo, to try and reduce the number of CI test failures.

See the commit message for more details.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
