### PR TITLE
Update URLs for pages to match page hierarchy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,10 +14,7 @@
   <%= render(ServiceNavigationComponent::View.new(
     navigation_items: [
       {text: "Get started", href: get_started_path},
-      # TODO: we need a better way to manage whether a service navigation link is active or not
-      {text: "About", href: about_path, active_when: [
-        features_path, forthcoming_features_path, create_good_forms_path, processing_completed_form_submissions_path,
-      ]},
+      {text: "About", href: about_path, active_when: about_path},
       {text: "Support", href: support_path},
     ],
     featured_link: {text: "Sign in", href: Settings.forms_admin.base_url}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,16 +6,23 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "pages#index"
 
-  get "/about" => "pages#about"
-  get "/get-started" => "pages#get_started"
-  get "/features" => "pages#features"
-  get "/forthcoming-features" => "pages#forthcoming_features"
-  get "/create-good-forms" => "pages#create_good_forms"
   get "/accessibility" => "pages#accessibility"
   get "/cookies" => "pages#cookies"
   get "/privacy" => "pages#privacy"
   get "/terms-of-use" => "pages#terms_of_use"
-  get "/processing-completed-form-submissions" => "pages#processing_completed_form_submissions"
+
+  get "/get-started" => "pages#get_started"
+
+  get "/about" => "pages#about"
+  get "/about/features" => "pages#features", as: :features
+  get "/about/forthcoming-features" => "pages#forthcoming_features", as: :forthcoming_features
+  get "/about/create-good-forms" => "pages#create_good_forms", as: :create_good_forms
+  get "/about/processing-completed-form-submissions" => "pages#processing_completed_form_submissions", as: :processing_completed_form_submissions
+
+  get "/features" => redirect("/about/features")
+  get "/forthcoming-features" => redirect("/about/forthcoming-features")
+  get "/create-good-forms" => redirect("/about/create-good-forms")
+  get "/processing-completed-form-submissions" => redirect("/about/processing-completed-form-submissions")
 
   get "/mailing-list" => redirect("https://service.us12.list-manage.com/subscribe?u=cb74eb9a6898b0e5870fede0a&id=451fe4c1e1")
 

--- a/spec/components/service_navigation_component/view_spec.rb
+++ b/spec/components/service_navigation_component/view_spec.rb
@@ -7,7 +7,7 @@ end
 RSpec.describe ServiceNavigationComponent::View, type: :component do
   let(:navigation_items) do
     [
-      { text: "Features", href: "/features" },
+      { text: "About", href: "/about" },
       { text: "Support", href: "/support" },
     ]
   end
@@ -61,7 +61,7 @@ RSpec.describe ServiceNavigationComponent::View, type: :component do
       end
     end
 
-    %w[features support].each do |view|
+    %w[about support].each do |view|
       context "when on the #{view} page" do
         let(:current_page) { "/#{view}" }
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe "Pages", type: :request do
   end
 
   %w[get-started
+     about
      features
      forthcoming-features
      create-good-forms
+     processing-completed-form-submissions
      accessibility
      privacy
      support

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -15,16 +15,18 @@ RSpec.describe "Pages", type: :request do
     end
   end
 
-  %w[get-started
-     about
-     features
-     forthcoming-features
-     create-good-forms
-     processing-completed-form-submissions
-     accessibility
-     privacy
-     support
-     terms-of-use].each do |page|
+  %w[
+    accessibility
+    privacy
+    support
+    terms-of-use
+    get-started
+    about
+    about/features
+    about/forthcoming-features
+    about/create-good-forms
+    about/processing-completed-form-submissions
+  ].each do |page|
     describe "GET /#{page}" do
       it "returns ok" do
         get "/#{page}"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/MOcbW9Oi/2853-add-sub-navigation-to-forms-product-page <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to update the routes for pages to match the hierarchy/sitemap of the pages; this mainly means that pages that live under "About" should also have their path start with `/about`.

For instance, the page at `/create-good-forms` now lives at `/about/create-good-forms`.

We add 301 Moved Permanently redirects for the old URLs, to make sure that existing links outside of the product page app still work.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
