### PR TITLE
Bump bundler from 4.0.8 to 4.0.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,4 +592,4 @@ RUBY VERSION
   ruby 3.4.8p72
 
 BUNDLED WITH
-  4.0.8
+  4.0.13


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Bumps [bundler](https://github.com/ruby/rubygems/tree/master/bundler) from 4.0.8 to 4.0.13.
- [Release notes](https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.13)
- [Changelog](https://github.com/ruby/rubygems/blob/bundler-v4.0.13/bundler/CHANGELOG.md)
- [Commits](https://github.com/ruby/rubygems/compare/bundler-v4.0.8...bundler-v4.0.13)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
