### PR TITLE
Add links to About page and remove a couple of mailing list links

### DIFF
--- a/app/views/pages/about.html.markerb
+++ b/app/views/pages/about.html.markerb
@@ -16,3 +16,9 @@ These are the steps to make a form with GOV.UK Forms.
 5. Publish a link to the form on GOV.UK along with any guidance people need to read before they complete the form.
 6. By default, answers for each completed form will be sent in the body of an email - to the email address you specified. You can also get the answers in a CSV or JSON file.
 
+## Features of GOV.UK Forms
+
+Find out more about:
+
+- <%= govuk_link_to "features", features_path %> already available in the platform
+- <%= govuk_link_to "forthcoming features", forthcoming_features_path %> that will be available in the near future

--- a/app/views/pages/features.html.markerb
+++ b/app/views/pages/features.html.markerb
@@ -127,7 +127,4 @@ Using these tested and accessible designs means you do not have to worry about t
 
 When new features are released, we'll email users of the product and update this page.
 
-You can also:
-
-- <%= govuk_link_to "read about our forthcoming features", forthcoming_features_path %>
-- <%= govuk_link_to "join our mailing list to get updates", mailing_list_path %>
+You can also <%= govuk_link_to "read about our forthcoming features", forthcoming_features_path %>.

--- a/app/views/pages/forthcoming_features.html.markerb
+++ b/app/views/pages/forthcoming_features.html.markerb
@@ -7,7 +7,7 @@ These are the features we're working on next and approximately when we hope to r
 
 This information is just a guide. It's not everything we're doing, and things may move.
 
-We'll update everyone with an account when we release new features. Or you can <%= govuk_link_to "sign up to our mailing list for updates", mailing_list_path %>.
+We'll update everyone with an account when we release new features.
 
 ## What we're working on now
 


### PR DESCRIPTION
### What problem does this pull request solve?

The 'About' page was created by splitting the 'Features' page in two. It ended quite abruptly and didn't offer an onward journey, so this adds a couple of links to where people might logically go next.

Also removes two links to the mailing list as we're decommissioning it. There are other links that we'll deal with separately.

Trello card:https://trello.com/c/f4KFZ3wl/3148-review-and-update-the-about-and-features-pages-on-the-product-site

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
