### PR TITLE
Add request type step to support form

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -11,27 +11,43 @@ class SupportController < ApplicationController
     end
 
     case @support_form.i_need_help_with.to_sym
-    when :using_forms
-      redirect_to :help_using_forms
-    when :about_forms
-      redirect_to :question_about_forms
-    when :other_government_service
+    when :government_service_team
+      redirect_to :support_request_type
+    when :public
       redirect_to "https://www.gov.uk/contact", status: :see_other, allow_other_host: true
     end
   end
 
-  def help_using_forms
-    @support_form = SupportForm.new(i_need_help_with: :using_forms)
-    render :form
+  def request_type
+    @support_form = SupportForm.new(i_need_help_with: "government_service_team")
   end
 
-  def question_about_forms
-    @support_form = SupportForm.new(i_need_help_with: :about_forms)
+  def select_request_type
+    @support_form = SupportForm.new(government_service_team_params)
+
+    if @support_form.invalid?(:request_type)
+      render :request_type and return
+    end
+
+    redirect_to support_form_path(request_type: @support_form.request_type)
+  end
+
+  def form
+    @support_form = SupportForm.new(i_need_help_with: "government_service_team", request_type: params[:request_type])
+
+    if @support_form.invalid?(:request_type)
+      redirect_to :support_request_type and return
+    end
+
     render :form
   end
 
   def submit
-    @support_form = SupportForm.new(support_form_params)
+    @support_form = SupportForm.new(government_service_team_params)
+
+    if @support_form.invalid?(:request_type)
+      redirect_to :support_request_type and return
+    end
 
     if @support_form.submit
       render :confirmation
@@ -45,6 +61,10 @@ private
   def support_form_params
     params
       .require(:support_form)
-      .permit(:i_need_help_with, :message, :question, :name, :email_address)
+      .permit(:i_need_help_with, :request_type, :message, :question, :name, :email_address)
+  end
+
+  def government_service_team_params
+    support_form_params.merge(i_need_help_with: "government_service_team")
   end
 end

--- a/app/form_objects/support_form.rb
+++ b/app/form_objects/support_form.rb
@@ -3,31 +3,84 @@ class SupportForm
   include ActiveModel::Validations
 
   EMAIL_REGEX = /.*@.*/
-  I_NEED_HELP_WITH_OPTIONS = %w[using_forms about_forms other_government_service].freeze
+  I_NEED_HELP_WITH_OPTIONS = %w[government_service_team public].freeze
+  REQUEST_TYPE_OPTIONS = %w[help_using technical_issue feature_request general_question something_else].freeze
 
-  attr_accessor :i_need_help_with, :message, :name, :email_address
+  attr_accessor :i_need_help_with, :request_type, :message, :name, :email_address
 
   alias_attribute :question, :message
 
   validates :i_need_help_with, presence: true, inclusion: { in: I_NEED_HELP_WITH_OPTIONS }
-  validates :i_need_help_with, presence: true, inclusion: { in: I_NEED_HELP_WITH_OPTIONS - %w[other_government_service] }, on: :submit
+  validates :i_need_help_with, presence: true, inclusion: { in: %w[government_service_team] }, on: :submit
+  validates :request_type, presence: true, on: %i[request_type submit], if: :government_service_team?
+  validates :request_type, inclusion: { in: REQUEST_TYPE_OPTIONS }, on: %i[request_type submit], if: :government_service_team?, allow_blank: true
   validates :email_address, presence: true, format: { with: EMAIL_REGEX, message: :invalid_email }, on: :submit
   validates :name, presence: true, on: :submit
-  validates :message, presence: true, on: :submit
-  validates :question, presence: true, on: :submit
+  validates :message, presence: true, on: :submit, unless: :general_question?
+  validates :question, presence: true, on: :submit, if: :general_question?
+
+  def government_service_team?
+    i_need_help_with.to_s == "government_service_team"
+  end
+
+  def general_question?
+    request_type.to_s == "general_question"
+  end
+
+  def support_message_attribute
+    general_question? ? :question : :message
+  end
+
+  def support_page_title
+    return I18n.t("page_titles.support.request_details.#{request_type}") if request_type_selected?
+
+    I18n.t("page_titles.support.form")
+  end
+
+  def support_message_label
+    return I18n.t("helpers.label.support_form.request_details.#{request_type}") if request_type_selected?
+
+    I18n.t("helpers.label.support_form.message")
+  end
+
+  def support_message_hint
+    return unless request_type_selected?
+
+    I18n.t("helpers.hint.support_form.request_details.#{request_type}", default: nil)
+  end
 
   def submit
     return false if invalid?(:submit)
 
     tags = {
-      "using_forms" => %w[govuk_forms_support],
-      "about_forms" => %w[govuk_forms_enquiries],
-    }[i_need_help_with]
+      "general_question" => %w[govuk_forms_enquiries],
+    }.fetch(request_type, %w[govuk_forms_support])
+    tags << request_type if request_type.present?
 
     ZendeskTicketService.create!(
-      comment: { body: message },
+      comment: { body: zendesk_message },
       requester: { name:, email: email_address },
       tags:,
     )
+  end
+
+private
+
+  def zendesk_message
+    <<~MESSAGE
+      Request type: #{request_type_label}
+
+      #{support_message_label}:
+
+      #{message}
+    MESSAGE
+  end
+
+  def request_type_label
+    I18n.t("helpers.label.support_form.request_type_options.#{request_type}")
+  end
+
+  def request_type_selected?
+    government_service_team? && REQUEST_TYPE_OPTIONS.include?(request_type.to_s)
   end
 end

--- a/app/views/support/form.html.erb
+++ b/app/views/support/form.html.erb
@@ -1,16 +1,24 @@
-<% set_page_title(title_with_error_prefix(t("page_titles.support.#{@support_form.i_need_help_with}"), error: @support_form.errors.any?)) %>
+<% set_page_title(title_with_error_prefix(@support_form.support_page_title, error: @support_form.errors.any?)) %>
 <% set_page_robots("noindex") %>
 
-<% content_for :back_link, govuk_back_link(href: support_path) %>
+<% content_for :back_link, govuk_back_link(href: support_request_type_path) %>
 
 <%= form_with model: @support_form, url: false do |f| %>
   <% f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-l"><%= t("page_titles.support.#{@support_form.i_need_help_with}") %></h1>
+  <h1 class="govuk-heading-l"><%= @support_form.support_page_title %></h1>
 
-  <%= f.hidden_field :i_need_help_with %>
+  <%= f.hidden_field :request_type %>
 
-  <%= f.govuk_text_area @support_form.i_need_help_with.to_sym == :using_forms ? :message : :question, rows: 10, spellcheck: true %>
+  <% message_options = {
+       rows: 10,
+       spellcheck: true,
+       label: { text: @support_form.support_message_label },
+     } %>
+  <% message_hint = @support_form.support_message_hint %>
+  <% message_options[:hint] = { text: message_hint } if message_hint.present? %>
+
+  <%= f.govuk_text_area @support_form.support_message_attribute, **message_options %>
   <%= f.govuk_text_field :name, autocomplete: :name, spellcheck: false %>
   <%= f.govuk_email_field :email_address, autocomplete: :email, spellcheck: false %>
 

--- a/app/views/support/request_type.html.erb
+++ b/app/views/support/request_type.html.erb
@@ -1,0 +1,18 @@
+<% set_page_title(title_with_error_prefix(t("page_titles.support.request_type"), error: @support_form.errors.any?)) %>
+<% set_page_robots("noindex") %>
+
+<% content_for :back_link, govuk_back_link(href: support_path) %>
+
+<%= form_with model: @support_form, url: select_support_request_type_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons(
+      :request_type,
+      SupportForm::REQUEST_TYPE_OPTIONS,
+      ->(option) { option },
+      ->(option) { t("helpers.label.support_form.request_type_options.#{option}") },
+      legend: { text: t("helpers.legend.support_form.request_type"), size: "l", tag: "h1" },
+    )
+  %>
+  <%= f.govuk_submit t("continue") %>
+<% end %>

--- a/config/locales/support.yml
+++ b/config/locales/support.yml
@@ -11,31 +11,58 @@ en:
             i_need_help_with:
               blank: Select one option
             message:
-              blank: Enter your message
+              blank: Enter details of your request
             name:
               blank: Enter your name
             question:
               blank: Enter your question
+            request_type:
+              blank: Select what your request is about
+              inclusion: Select what your request is about
   helpers:
+    hint:
+      support_form:
+        request_details:
+          feature_request: Tell us what you want to change or improve and why it would help.
+          help_using: Tell us what you want to do and where you got stuck.
+          technical_issue: Tell us what happened, what you expected to happen and which form you were using.
     label:
       support_form:
         email_address: Your email address
         i_need_help_with_options:
-          about_forms: I work in a government service team and have a question about GOV.UK Forms
-          other_government_service: I’m a member of the public with a question about a government form or service
-          using_forms: I work in a government service team and need help using GOV.UK Forms
-        message: Your message
+          government_service_team: I work in a government service team
+          public: I’m a member of the public with a question about a government form or service
+        message: Details of your request
         name: Your name
         question: Your question
+        request_details:
+          feature_request: What would you like to change or improve?
+          help_using: What do you need help to do?
+          technical_issue: What is the problem?
+          general_question: What is your question?
+          something_else: Tell us what your request is about
+        request_type_options:
+          feature_request: Suggesting a new feature or improvement
+          general_question: A general question about GOV.UK Forms
+          help_using: Getting help using GOV.UK Forms
+          something_else: Something else
+          technical_issue: A technical problem or something is not working as expected
     legend:
       support_form:
-        i_need_help_with: What do you need help with?
+        i_need_help_with: Who are you?
+        request_type: What is your request about?
   page_titles:
     support:
-      about_forms: Question about GOV.UK Forms
       confirmation: Message sent
+      form: Contact GOV.UK Forms support
+      request_type: What is your request about?
+      request_details:
+        feature_request: Suggest a feature or improvement to GOV.UK Forms
+        general_question: Question about GOV.UK Forms
+        help_using: Help using GOV.UK Forms
+        something_else: Contact GOV.UK Forms support
+        technical_issue: Report a technical problem with GOV.UK Forms
       support: Support
-      using_forms: Help using GOV.UK Forms
   support:
     confirmation:
       body_html: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,10 +34,12 @@ Rails.application.routes.draw do
 
   get "/support" => "support#support", as: :support
   post "/support" => "support#new", as: :new_support_message
-  get "/support/help-using-forms" => "support#help_using_forms", as: :help_using_forms
-  post "/support/help-using-forms" => "support#submit"
-  get "/support/question-about-forms" => "support#question_about_forms", as: :question_about_forms
-  post "/support/question-about-forms" => "support#submit"
+  get "/support/help-using-forms" => redirect("/support/form?request_type=help_using")
+  get "/support/question-about-forms" => redirect("/support/form?request_type=general_question")
+  get "/support/request-type" => "support#request_type", as: :support_request_type
+  post "/support/request-type" => "support#select_request_type", as: :select_support_request_type
+  get "/support/form" => "support#form", as: :support_form
+  post "/support/form" => "support#submit"
 
   get "/json-submissions/v1/schema" => "json_submissions#schema_v1", as: :json_submissions_schema_v1
 

--- a/spec/features/support_form_spec.rb
+++ b/spec/features/support_form_spec.rb
@@ -9,18 +9,22 @@ describe "Support form", type: :system do
       visit support_path
     end
 
-    it "asks users what they need help with" do
+    it "asks users who they are" do
       expect(page).to have_text "Support"
-      expect(page).to have_text "What do you need help with?"
-      expect(page).to have_field("support_form[i_need_help_with]", type: :radio, visible: :all).exactly(3).times
+      expect(page).to have_text "Who are you?"
+      expect(page).to have_field("support_form[i_need_help_with]", type: :radio, visible: :all).exactly(2).times
     end
 
-    scenario "a civil servant needs help using GOV.UK Forms" do
-      choose "I work in a government service team and need help using GOV.UK Forms", visible: :all
+    scenario "a government service team member asks a general question about GOV.UK Forms" do
+      choose "I work in a government service team", visible: :all
       click_button "Continue"
 
-      expect(page).to have_text "Help using GOV.UK Forms"
-      fill_in "Your message", with: "I need help using GOV.UK Forms"
+      expect(page).to have_text "What is your request about?"
+      choose "A general question about GOV.UK Forms", visible: :all
+      click_button "Continue"
+
+      expect(page).to have_text "Question about GOV.UK Forms"
+      fill_in "What is your question?", with: "How does GOV.UK Forms work?"
       fill_in "Your name", with: "Test User"
       fill_in "Your email address", with: "test@example.com"
       click_button "Send"
@@ -28,12 +32,16 @@ describe "Support form", type: :system do
       expect(page).to have_text "Message sent"
     end
 
-    scenario "a civil servant has a question about GOV.UK Forms" do
-      choose "I work in a government service team and have a question about GOV.UK Forms", visible: :all
+    scenario "a government service team member suggests an improvement" do
+      choose "I work in a government service team", visible: :all
       click_button "Continue"
 
-      expect(page).to have_text "Question about GOV.UK Forms"
-      fill_in "Your question", with: "I have a question about GOV.UK Forms"
+      expect(page).to have_text "What is your request about?"
+      choose "Suggesting a new feature or improvement", visible: :all
+      click_button "Continue"
+
+      expect(page).to have_text "Suggest a feature or improvement to GOV.UK Forms"
+      fill_in "What would you like to change or improve?", with: "Add a way to duplicate questions"
       fill_in "Your name", with: "Test User"
       fill_in "Your email address", with: "test@example.com"
       click_button "Send"
@@ -42,7 +50,7 @@ describe "Support form", type: :system do
     end
   end
 
-  scenario "a member of the public is looking for help with a form" do
+  scenario "a member of the public is redirected to the contact page" do
     visit support_path
     choose "I’m a member of the public with a question about a government form or service", visible: :all
     click_button "Continue"

--- a/spec/form_objects/support_form_spec.rb
+++ b/spec/form_objects/support_form_spec.rb
@@ -4,25 +4,26 @@ describe SupportForm, type: :model do
   describe "validations" do
     SupportForm::I_NEED_HELP_WITH_OPTIONS.each do |option|
       it "is valid if i_need_help_with is set to #{option}" do
-        expect(described_class.new(i_need_help_with: option))
-          .to be_valid
+        expect(described_class.new(i_need_help_with: option)).to be_valid
       end
     end
 
     it "is valid to submit if all attributes are present" do
       expect(described_class.new(
-               i_need_help_with: "using_forms",
-               message: "I need help using GOV.UK Forms",
+               i_need_help_with: "government_service_team",
+               request_type: "feature_request",
+               message: "Add an autosave feature",
                name: "A. User",
                email_address: "test@example.com",
              )).to be_valid(:submit)
     end
 
-    %i[i_need_help_with message name email_address].each do |attr|
+    %i[i_need_help_with request_type message name email_address].each do |attr|
       it "is not valid to submit if #{attr} is not present" do
         attrs = {
-          i_need_help_with: "using_forms",
-          message: "I need help using GOV.UK Forms",
+          i_need_help_with: "government_service_team",
+          request_type: "feature_request",
+          message: "Add an autosave feature",
           name: "A. User",
           email_address: "test@example.com",
         }
@@ -31,14 +32,28 @@ describe SupportForm, type: :model do
         support_form = described_class.new(**attrs)
 
         expect(support_form).not_to be_valid(:submit)
-        expect(support_form.errors).to be_added attr, :blank
+        expect(support_form.errors).to be_added(attr, :blank)
       end
     end
 
-    it "is not valid to submit if i_need_help_with is set to other_government_service" do
+    it "is valid to continue from the request type step when a request type is selected" do
       expect(described_class.new(
-               i_need_help_with: "other_government_service",
-               message: "I need help using GOV.UK Forms",
+               i_need_help_with: "government_service_team",
+               request_type: "feature_request",
+             )).to be_valid(:request_type)
+    end
+
+    it "is not valid to continue from the request type step without a request type" do
+      support_form = described_class.new(i_need_help_with: "government_service_team")
+
+      expect(support_form).not_to be_valid(:request_type)
+      expect(support_form.errors).to be_added(:request_type, :blank)
+    end
+
+    it "is not valid to submit if i_need_help_with is public" do
+      expect(described_class.new(
+               i_need_help_with: "public",
+               message: "I need help with a form",
                name: "A. User",
                email_address: "test@example.com",
              )).not_to be_valid(:submit)
@@ -46,14 +61,27 @@ describe SupportForm, type: :model do
 
     it "is not valid to submit if email_address is not an email address" do
       support_form = described_class.new(
-        i_need_help_with: "using_forms",
-        message: "I need help using GOV.UK Forms",
+        i_need_help_with: "government_service_team",
+        request_type: "feature_request",
+        message: "Add an autosave feature",
         name: "A. User",
         email_address: "not_an_email_address",
       )
 
       expect(support_form).not_to be_valid(:submit)
       expect(support_form.errors.where(:email_address, message: :invalid_email)).to be_truthy
+    end
+
+    it "is not valid to submit a general question without a question" do
+      support_form = described_class.new(
+        i_need_help_with: "government_service_team",
+        request_type: "general_question",
+        name: "A. User",
+        email_address: "test@example.com",
+      )
+
+      expect(support_form).not_to be_valid(:submit)
+      expect(support_form.errors).to be_added(:question, :blank)
     end
   end
 
@@ -62,10 +90,10 @@ describe SupportForm, type: :model do
       allow(ZendeskTicketService).to receive(:create!).and_return(true)
     end
 
-    it "does not submit if user needs help with another government service" do
+    it "does not submit if the user is a member of the public" do
       support_form = described_class.new(
-        i_need_help_with: "other_government_service",
-        message: "I need help with my tax return",
+        i_need_help_with: "public",
+        message: "I need help with a form",
         name: "A. User",
         email_address: "test@example.com",
       )
@@ -76,8 +104,9 @@ describe SupportForm, type: :model do
 
     it "submits the user's message as a Zendesk ticket" do
       support_form = described_class.new(
-        i_need_help_with: "using_forms",
-        message: "I need help with GOV.UK Forms",
+        i_need_help_with: "government_service_team",
+        request_type: "feature_request",
+        message: "Add an autosave feature",
         name: "A. User",
         email_address: "test@example.com",
       )
@@ -85,30 +114,50 @@ describe SupportForm, type: :model do
       expect(support_form.submit).to be_truthy
       expect(ZendeskTicketService).to have_received(:create!).with(
         hash_including(
-          comment: { body: "I need help with GOV.UK Forms" },
+          comment: {
+            body: <<~MESSAGE,
+              Request type: Suggesting a new feature or improvement
+
+              What would you like to change or improve?:
+
+              Add an autosave feature
+            MESSAGE
+          },
           requester: { name: "A. User", email: "test@example.com" },
         ),
       )
     end
 
-    [
-      %w[using_forms govuk_forms_support],
-      %w[about_forms govuk_forms_enquiries],
-    ].each do |i_need_help_with, tag|
-      it "tags the Zendesk ticket with what they need help with" do
-        described_class.new(
-          i_need_help_with:,
-          message: "My message",
-          name: "A. User",
-          email_address: "test@example.com",
-        ).submit
+    it "tags general questions as enquiries" do
+      described_class.new(
+        i_need_help_with: "government_service_team",
+        request_type: "general_question",
+        question: "How does GOV.UK Forms work?",
+        name: "A. User",
+        email_address: "test@example.com",
+      ).submit
 
-        expect(ZendeskTicketService).to have_received(:create!).with(
-          hash_including(
-            tags: [tag],
-          ),
-        )
-      end
+      expect(ZendeskTicketService).to have_received(:create!).with(
+        hash_including(
+          tags: %w[govuk_forms_enquiries general_question],
+        ),
+      )
+    end
+
+    it "tags support requests with the support tag" do
+      described_class.new(
+        i_need_help_with: "government_service_team",
+        request_type: "technical_issue",
+        message: "My form is not loading",
+        name: "A. User",
+        email_address: "test@example.com",
+      ).submit
+
+      expect(ZendeskTicketService).to have_received(:create!).with(
+        hash_including(
+          tags: %w[govuk_forms_support technical_issue],
+        ),
+      )
     end
   end
 end

--- a/spec/views/support/form.html.erb_spec.rb
+++ b/spec/views/support/form.html.erb_spec.rb
@@ -1,34 +1,76 @@
 require "rails_helper"
 
 describe "support/form.html.erb", type: :view do
-  let(:i_need_help_with) { "using_forms" }
+  let(:request_type) { "help_using" }
 
   before do
-    assign(:support_form, SupportForm.new(i_need_help_with:))
+    assign(:support_form, SupportForm.new(i_need_help_with: "government_service_team", request_type:))
 
     render template: "support/form"
   end
 
-  context "when the user needs help using GOV.UK Forms" do
-    let(:i_need_help_with) { "using_forms" }
+  context "when the request is a feature request" do
+    let(:request_type) { "feature_request" }
 
-    it "asks for a message" do
+    it "asks for the change they need" do
+      expect(rendered).to have_text "Suggest a feature or improvement to GOV.UK Forms"
+
       expect(rendered).to have_field "support_form[message]" do |field|
         expect(field.tag_name).to eq "textarea"
         expect(field[:spellcheck]).to eq "true"
       end
+
+      expect(rendered).to have_text "What would you like to change or improve?"
+      expect(rendered).to have_text "Tell us what you want to change or improve and why it would help."
     end
   end
 
-  context "when the user has a question about GOV.UK Forms" do
-    let(:i_need_help_with) { "about_forms" }
+  context "when the request is a technical issue" do
+    let(:request_type) { "technical_issue" }
+
+    it "asks for the problem details" do
+      expect(rendered).to have_text "Report a technical problem with GOV.UK Forms"
+      expect(rendered).to have_text "What is the problem?"
+      expect(rendered).to have_text "Tell us what happened, what you expected to happen and which form you were using."
+    end
+  end
+
+  context "when the request is getting help using GOV.UK Forms" do
+    let(:request_type) { "help_using" }
+
+    it "asks what the user needs help to do" do
+      expect(rendered).to have_text "Help using GOV.UK Forms"
+      expect(rendered).to have_text "What do you need help to do?"
+      expect(rendered).to have_text "Tell us what you want to do and where you got stuck."
+    end
+  end
+
+  context "when the request is a general question" do
+    let(:request_type) { "general_question" }
 
     it "asks for a question" do
+      expect(rendered).to have_text "Question about GOV.UK Forms"
+
       expect(rendered).to have_field "support_form[question]" do |field|
         expect(field.tag_name).to eq "textarea"
         expect(field[:spellcheck]).to eq "true"
       end
+
+      expect(rendered).to have_text "What is your question?"
     end
+  end
+
+  context "when the request is something else" do
+    let(:request_type) { "something_else" }
+
+    it "asks for general request details" do
+      expect(rendered).to have_text "Contact GOV.UK Forms support"
+      expect(rendered).to have_text "Tell us what your request is about"
+    end
+  end
+
+  it "includes the selected request type as a hidden field" do
+    expect(rendered).to have_field("support_form[request_type]", type: "hidden", with: request_type)
   end
 
   it "asks for a name" do

--- a/spec/views/support/request_type.html.erb_spec.rb
+++ b/spec/views/support/request_type.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "support/request_type.html.erb", type: :view do
+  before do
+    assign(:support_form, SupportForm.new(i_need_help_with: "government_service_team"))
+
+    render template: "support/request_type"
+  end
+
+  it "asks what the request is about" do
+    expect(rendered).to have_text "What is your request about?"
+    expect(rendered).to have_field("support_form[request_type]", type: :radio, visible: :all).exactly(5).times
+    expect(rendered).to have_text "Getting help using GOV.UK Forms"
+    expect(rendered).to have_text "A technical problem or something is not working as expected"
+    expect(rendered).to have_text "Suggesting a new feature or improvement"
+    expect(rendered).to have_text "A general question about GOV.UK Forms"
+    expect(rendered).to have_text "Something else"
+  end
+
+  it "shows an error summary when a request type has not been selected" do
+    support_form = SupportForm.new(i_need_help_with: "government_service_team")
+    support_form.invalid?(:request_type)
+    assign(:support_form, support_form)
+
+    render template: "support/request_type"
+
+    expect(rendered).to have_css ".govuk-error-summary"
+    expect(rendered).to have_text "Select what your request is about"
+  end
+end


### PR DESCRIPTION
Replace the separate help and question pages with a two-step flow: users in government service teams first select what their request is about, then complete a form tailored to that request type. This captures more specific support requests and tags Zendesk tickets with the request type.

The old support page URLs redirect to their closest equivalent in the new flow.