### PR TITLE
Namespace compiled assets under app name

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -6,7 +6,7 @@
       "~/{assets,fonts,icons,images}/**/*",
       "node_modules/govuk-frontend/dist/govuk/assets/**/*"
     ],
-    "publicOutputDir": "assets",
+    "publicOutputDir": "assets/forms-product-page",
     "assetsDir": ""
   },
   "development": {


### PR DESCRIPTION
## What
Changes Vite's `publicOutputDir` from `assets` to `assets/forms-product-page`, so production assets compile to `public/assets/forms-product-page/` and all generated asset URLs use the `/assets/forms-product-page/` prefix.

## Why
We are working on serving production assets from a shared S3 bucket instead of from the Rails container. Multiple apps will upload their assets to the same bucket, so each app needs its own key prefix to avoid collisions. Syncing `public/assets/` to the bucket now produces the `assets/forms-product-page/` namespace automatically.

## Notes
- Development and test are unaffected: they override `publicOutputDir` with `vite-dev`/`vite-test` and keep being served by the Vite dev server.
- The compiled files still sit under `public/` at the same path as their URLs, so the Rails container can continue serving them directly until S3 serving is in place (and in review apps).
- Verified with a production build: `vite_asset_path` returns `/assets/forms-product-page/application-<digest>.js`, and URLs inside the compiled CSS (fonts, images) use the new prefix too.
- The existing `.gitignore` entry `/public/assets` still covers the new output; no Dockerfile changes needed.