### PR TITLE
Fix error summary on support form

### DIFF
--- a/app/form_objects/support_form.rb
+++ b/app/form_objects/support_form.rb
@@ -11,10 +11,10 @@ class SupportForm
 
   validates :i_need_help_with, presence: true, inclusion: { in: I_NEED_HELP_WITH_OPTIONS }
   validates :i_need_help_with, presence: true, inclusion: { in: I_NEED_HELP_WITH_OPTIONS - %w[other_government_service] }, on: :submit
-  validates :email_address, presence: true, format: { with: EMAIL_REGEX, message: :invalid_email }, on: :submit
+  validates :message, presence: true, on: :submit, if: :i_need_help_with_using_forms?
+  validates :question, presence: true, on: :submit, unless: :i_need_help_with_using_forms?
   validates :name, presence: true, on: :submit
-  validates :message, presence: true, on: :submit
-  validates :question, presence: true, on: :submit
+  validates :email_address, presence: true, format: { with: EMAIL_REGEX, message: :invalid_email }, on: :submit
 
   def submit
     return false if invalid?(:submit)
@@ -29,5 +29,11 @@ class SupportForm
       requester: { name:, email: email_address },
       tags:,
     )
+  end
+
+  def i_need_help_with_using_forms?
+    return false if i_need_help_with.blank?
+
+    i_need_help_with.to_sym == :using_forms
   end
 end

--- a/app/views/support/form.html.erb
+++ b/app/views/support/form.html.erb
@@ -12,20 +12,12 @@
         </h2>
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
-            <% if @support_form.errors.include?(:message) %>
-              <li>
-                <a href="#support-form-message-field-error"><%= @support_form.errors.messages_for(:message).first %></a>
-              </li>
-            <% end %>
-            <% if @support_form.errors.include?(:name) %>
-              <li>
-                <a href="#support-form-name-field-error"><%= @support_form.errors.messages_for(:name).first %></a>
-              </li>
-            <% end %>
-            <% if @support_form.errors.include?(:email_address) %>
-              <li>
-                <a href="#support-form-email-address-field-error"><%= @support_form.errors.messages_for(:email_address).first %></a>
-              </li>
+            <% @support_form.methods.each do |attribute| %>
+              <% if @support_form.errors.include?(attribute) %>
+                <li>
+                  <a href="#support-form-<%= attribute.to_s.dasherize %>-field-error"><%= @support_form.errors.messages_for(attribute).first %></a>
+                </li>
+              <% end %>
             <% end %>
           </ul>
         </div>

--- a/app/views/support/form.html.erb
+++ b/app/views/support/form.html.erb
@@ -4,7 +4,34 @@
 <% content_for :back_link, govuk_back_link(href: support_path) %>
 
 <%= form_with model: @support_form, url: false do |f| %>
-  <% f.govuk_error_summary %>
+  <% if @support_form.errors.any? %>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">
+          There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <% if @support_form.errors.include?(:message) %>
+              <li>
+                <a href="#support-form-message-field-error"><%= @support_form.errors.messages_for(:message).first %></a>
+              </li>
+            <% end %>
+            <% if @support_form.errors.include?(:name) %>
+              <li>
+                <a href="#support-form-name-field-error"><%= @support_form.errors.messages_for(:name).first %></a>
+              </li>
+            <% end %>
+            <% if @support_form.errors.include?(:email_address) %>
+              <li>
+                <a href="#support-form-email-address-field-error"><%= @support_form.errors.messages_for(:email_address).first %></a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <%end%>
 
   <h1 class="govuk-heading-l"><%= t("page_titles.support.#{@support_form.i_need_help_with}") %></h1>
 

--- a/app/views/support/form.html.erb
+++ b/app/views/support/form.html.erb
@@ -4,26 +4,7 @@
 <% content_for :back_link, govuk_back_link(href: support_path) %>
 
 <%= form_with model: @support_form, url: false do |f| %>
-  <% if @support_form.errors.any? %>
-    <div class="govuk-error-summary" data-module="govuk-error-summary">
-      <div role="alert">
-        <h2 class="govuk-error-summary__title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% @support_form.methods.each do |attribute| %>
-              <% if @support_form.errors.include?(attribute) %>
-                <li>
-                  <a href="#support-form-<%= attribute.to_s.dasherize %>-field-error"><%= @support_form.errors.messages_for(attribute).first %></a>
-                </li>
-              <% end %>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    </div>
-  <%end%>
+  <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-l"><%= t("page_titles.support.#{@support_form.i_need_help_with}") %></h1>
 

--- a/app/views/support/support.html.erb
+++ b/app/views/support/support.html.erb
@@ -3,7 +3,7 @@
 <% set_page_robots("noindex") %>
 
 <%= form_with model: @support_form, url: new_support_message_path do |f| %>
-  <% f.govuk_error_summary %>
+  <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= t("page_titles.support.support") %></h1>
 
@@ -21,7 +21,7 @@
 <h2 class="govuk-heading-m">Check our system status</h2>
 
 <p>
-  If you have a problem with the platform, check for known issues on the <a href="https://status.forms.service.gov.uk">GOV.UK Forms system status page</a>. You can subscribe to get notifications about current and future issues. 
+  If you have a problem with the platform, check for known issues on the <a href="https://status.forms.service.gov.uk">GOV.UK Forms system status page</a>. You can subscribe to get notifications about current and future issues.
 </p>
 
 <h2 class="govuk-heading-m">Support during working hours</h2>

--- a/spec/form_objects/support_form_spec.rb
+++ b/spec/form_objects/support_form_spec.rb
@@ -10,12 +10,14 @@ describe SupportForm, type: :model do
     end
 
     it "is valid to submit if all attributes are present" do
-      expect(described_class.new(
-               i_need_help_with: "using_forms",
-               message: "I need help using GOV.UK Forms",
-               name: "A. User",
-               email_address: "test@example.com",
-             )).to be_valid(:submit)
+      support_form = described_class.new(
+        i_need_help_with: "using_forms",
+        message: "I need help using GOV.UK Forms",
+        name: "A. User",
+        email_address: "test@example.com",
+      )
+
+      expect(support_form).to be_valid(:submit)
     end
 
     %i[i_need_help_with message name email_address].each do |attr|
@@ -32,6 +34,40 @@ describe SupportForm, type: :model do
 
         expect(support_form).not_to be_valid(:submit)
         expect(support_form.errors).to be_added attr, :blank
+      end
+    end
+
+    context "when `message` has a validation error" do
+      it "adds an error to `message` but not `question`" do
+        attrs = {
+          i_need_help_with: "using_forms",
+          message: "",
+          name: "A. User",
+          email_address: "test@example.com",
+        }
+
+        support_form = described_class.new(**attrs)
+
+        expect(support_form).not_to be_valid(:submit)
+        expect(support_form.errors.full_messages_for(:message)).to eq ["Message Enter your message"]
+        expect(support_form.errors.full_messages_for(:question)).to be_empty
+      end
+    end
+
+    context "when `question` has a validation error" do
+      it "adds an error to `message` but not `question`" do
+        attrs = {
+          i_need_help_with: "about_forms",
+          question: "",
+          name: "A. User",
+          email_address: "test@example.com",
+        }
+
+        support_form = described_class.new(**attrs)
+
+        expect(support_form).not_to be_valid(:submit)
+        expect(support_form.errors.full_messages_for(:message)).to be_empty
+        expect(support_form.errors.full_messages_for(:question)).to eq ["Question Enter your question"]
       end
     end
 
@@ -108,6 +144,49 @@ describe SupportForm, type: :model do
             tags: [tag],
           ),
         )
+      end
+    end
+  end
+
+  describe "#i_need_help_with_using_forms?" do
+    let(:support_form) { described_class.new(i_need_help_with:) }
+    let(:i_need_help_with) { nil }
+
+    context "when i_need_help_with is nil" do
+      it "returns false" do
+        expect(support_form.i_need_help_with_using_forms?).to be false
+      end
+    end
+
+    context "when i_need_help_with is an empty string" do
+      let(:i_need_help_with) { "" }
+
+      it "returns false" do
+        expect(support_form.i_need_help_with_using_forms?).to be false
+      end
+    end
+
+    context "when i_need_help_with is about_forms" do
+      let(:i_need_help_with) { "about_forms" }
+
+      it "returns false" do
+        expect(support_form.i_need_help_with_using_forms?).to be false
+      end
+    end
+
+    context "when i_need_help_with is other_government_service" do
+      let(:i_need_help_with) { "other_government_service" }
+
+      it "returns false" do
+        expect(support_form.i_need_help_with_using_forms?).to be false
+      end
+    end
+
+    context "when i_need_help_with is using_forms" do
+      let(:i_need_help_with) { "using_forms" }
+
+      it "returns true" do
+        expect(support_form.i_need_help_with_using_forms?).to be true
       end
     end
   end

--- a/spec/views/support/form.html.erb_spec.rb
+++ b/spec/views/support/form.html.erb_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe "support/form.html.erb", type: :view do
   let(:i_need_help_with) { "using_forms" }
+  let(:support_form) { SupportForm.new(i_need_help_with:) }
 
   before do
-    assign(:support_form, SupportForm.new(i_need_help_with:))
+    assign(:support_form, support_form)
 
     render template: "support/form"
   end
@@ -16,6 +17,27 @@ describe "support/form.html.erb", type: :view do
       expect(rendered).to have_field "support_form[message]" do |field|
         expect(field.tag_name).to eq "textarea"
         expect(field[:spellcheck]).to eq "true"
+      end
+    end
+
+    context "when there is a validation error" do
+      let(:support_form) do
+        form = SupportForm.new(i_need_help_with:)
+        form.valid?(:submit)
+        form
+      end
+
+      it "renders the title with 'Error:' prefix" do
+        expect(view.content_for(:title)).to eq "Error: Help using GOV.UK Forms"
+      end
+
+      it "renders the error summary" do
+        expect(rendered).to have_text("There is a problem")
+        expect(rendered).to have_link(href: "#support-form-name-field-error", text: I18n.t("activemodel.errors.models.support_form.attributes.name.blank"))
+      end
+
+      it "renders a validation error on the field" do
+        expect(rendered).to have_css(".govuk-error-message", text: I18n.t("activemodel.errors.models.support_form.attributes.name.blank"))
       end
     end
   end
@@ -43,6 +65,27 @@ describe "support/form.html.erb", type: :view do
       expect(field[:autocomplete]).to eq "email"
       expect(field[:type]).to eq "email"
       expect(field[:spellcheck]).to eq "false"
+    end
+  end
+
+  context "when there is a validation error" do
+    let(:support_form) do
+      form = SupportForm.new(i_need_help_with:)
+      form.valid?(:submit)
+      form
+    end
+
+    it "renders the title with 'Error:' prefix" do
+      expect(view.content_for(:title)).to eq "Error: Help using GOV.UK Forms"
+    end
+
+    it "renders the error summary" do
+      expect(rendered).to have_text("There is a problem")
+      expect(rendered).to have_link(href: "#support-form-name-field-error", text: I18n.t("activemodel.errors.models.support_form.attributes.name.blank"))
+    end
+
+    it "renders a validation error on the field" do
+      expect(rendered).to have_css(".govuk-error-message", text: I18n.t("activemodel.errors.models.support_form.attributes.name.blank"))
     end
   end
 end

--- a/spec/views/support/support.html.erb_spec.rb
+++ b/spec/views/support/support.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "support/support.html.erb", type: :view do
+  let(:support_form) { SupportForm.new }
+
+  before do
+    assign(:support_form, support_form)
+
+    render template: "support/support"
+  end
+
+  it "asks what the user needs help with" do
+    expect(rendered).to have_css("legend", text: I18n.t("helpers.legend.support_form.i_need_help_with"))
+    expect(rendered).to have_field(I18n.t("helpers.label.support_form.i_need_help_with_options.about_forms"), type: "radio")
+    expect(rendered).to have_field(I18n.t("helpers.label.support_form.i_need_help_with_options.other_government_service"), type: "radio")
+    expect(rendered).to have_field(I18n.t("helpers.label.support_form.i_need_help_with_options.using_forms"), type: "radio")
+  end
+
+  it "renders the title" do
+    expect(view.content_for(:title)).to eq "Support"
+  end
+
+  context "when there is a validation error" do
+    let(:support_form) do
+      form = SupportForm.new
+      form.valid?(:submit)
+      form
+    end
+
+    it "renders the title with 'Error:' prefix" do
+      expect(view.content_for(:title)).to eq "Error: Support"
+    end
+
+    it "renders the error summary" do
+      expect(rendered).to have_text("There is a problem")
+      expect(rendered).to have_link(href: "#support-form-i-need-help-with-field-error", text: I18n.t("activemodel.errors.models.support_form.attributes.i_need_help_with.blank"))
+    end
+
+    it "renders a validation error on the field" do
+      expect(rendered).to have_css(".govuk-error-message", text: I18n.t("activemodel.errors.models.support_form.attributes.i_need_help_with.blank"))
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/AdQw8IES/3667-support-form-has-no-error-summary

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Fixes an issue with the error summary not appearing on the support form, so that users can easily see and navigate to the fields with errors.

Before:
<img width="674" height="643" alt="image" src="https://github.com/user-attachments/assets/4ac54a96-f726-46b0-bd8e-aff3c8258077" />
<img width="669" height="499" alt="image" src="https://github.com/user-attachments/assets/a9d4545f-5acd-4794-8470-d99f08bd7ecf" />


After:
<img width="695" height="763" alt="Screenshot 2026-07-09 at 16 47 25" src="https://github.com/user-attachments/assets/e9aca6a3-c5d1-47db-8183-241adda5ab93" />
<img width="693" height="744" alt="image" src="https://github.com/user-attachments/assets/9cb5209f-94ec-404d-be53-11a2a3ea549b" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
