### PR TITLE
Handle MissingTemplate errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
+  rescue_from ActionView::MissingTemplate do |exception|
+    if request.format && request.format != :html
+      head :not_acceptable
+    else
+      raise exception
+    end
+  end
+
   def append_info_to_payload(payload)
     super
     payload[:request_host] = request.host

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe ApplicationController, type: :controller do
     def index
       render body: nil
     end
+
+    def missing_template
+      render "missing_template"
+    end
+  end
+
+  before do
+    routes.draw do
+      get "missing_template" => "anonymous#missing_template"
+    end
   end
 
   describe "#append_info_to_payload" do
@@ -47,6 +57,17 @@ RSpec.describe ApplicationController, type: :controller do
       it "returns nil" do
         expect(controller.user_ip("")).to be_nil
       end
+    end
+  end
+
+  describe "missing template" do
+    it "returns 406 when request format is not HTML" do
+      get :missing_template, format: :json
+      expect(response).to have_http_status(:not_acceptable)
+    end
+
+    it "raises the error when the request format is HTML" do
+      expect { get :missing_template, format: :html }.to raise_error(ActionView::MissingTemplate)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/rFP7pQ46/

If a MissingTemplate error is raised, and the format requested was not HTML, handle the error by returning a 406 Not Acceptable response.

If the format requested was HTML, re-raise the error as we should not expect to be missing templates for HTML requests handled by the ApplicationController.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
